### PR TITLE
chore: copy GH templates from js-sdk repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,23 @@
+name: 🐞 Bug
+description: Found a bug? We are sorry about that! Let us know! 🐛
+title: "[BUG] "
+labels: [bug, Needs Triage]
+body:
+- type: textarea
+  attributes:
+    label: Observed behavior
+    description: What are you trying to do? Describe what you think went wrong during this.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: Describe as best you can the problem. Please provide us scenario file, logs or anything you have that can help us to understand.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,11 @@
+name: 📓 Documentation
+description: Any documentation related issue/addition.
+title: "[DOC] "
+labels: [documentation, Needs Triage]
+body:
+- type: textarea
+  attributes:
+    label: Change in the documentation
+    description: What should we add/remove/update in the documentation?
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,12 @@
+name: 💡 Feature
+description: Add new functionality to the project.
+title: "[FEATURE] "
+labels: [enhancement, Needs Triage]
+body:
+- type: textarea
+  attributes:
+    label: Requirements
+    description: |
+      Ask us what you want! Please provide as many details as possible and describe how it should work.
+  validations:
+    required: false

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,45 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,14 @@
-name: CI
+name: pr-checks
 
 on:
   pull_request:
-  push:
-    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+  merge_group:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
- copy over GH Issue templates from `js-sdk` repo.
- copy `lint-pr` and update `pr-checks` GH action from `js-sdk` repo.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
