### PR TITLE
chore: add publish environment to mcp-registry-publish workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,6 +80,7 @@ jobs:
     needs: [release-please, npm-release]
     runs-on: ubuntu-latest
     if: ${{ fromJSON(needs.release-please.outputs.release_created || 'false') }}
+    environment: publish
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Adds `publish` environment to the `mcp-registry-publish` to fix the publishing.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
