### PR TITLE
docs: add docs for codex and gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,35 @@ In the `Manage MCP servers` raw config, add:
 }
 ```
 
+### Codex CLI
+
+Edit `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.openfeature]
+command = "npx"
+args = ["-y", "@openfeature/mcp"]
+```
+
+Restart Codex CLI after saving.
+
+### Gemini CLI
+
+Edit `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "OpenFeature": {
+      "command": "npx",
+      "args": ["-y", "@openfeature/mcp"]
+    }
+  }
+}
+```
+
+Restart Gemini CLI after saving.
+
 ### Claude Desktop
 
 Edit your Claude Desktop config at:


### PR DESCRIPTION
Added docs for installing MCP into `Codex CLI` and `Gemini CLI`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"docs-add-cursor-vscode-install-links","parentHead":"8a2c2cb17ee964b48ca111648733788fe300604a","parentPull":36,"trunk":"main"}
```
-->
