### PR TITLE
fix: attempt to fix MCP server hanging

### DIFF
--- a/src/tools/installTools.ts
+++ b/src/tools/installTools.ts
@@ -25,8 +25,8 @@ function buildProviderPrompts(
       );
     }
 
-    console.error(`providerDocLinks: ${providerDocLinks}`);
-    console.error(`technology: ${technology}`);
+    console.error('providerDocLinks:', providerDocLinks);
+    console.error('technology:', technology);
     const perTechnologyUrl = providerDocLinks[technology] || '';
     if (perTechnologyUrl) {
       if (!DISABLE_RESOURCES) {

--- a/src/tools/ofrepTools.test.ts
+++ b/src/tools/ofrepTools.test.ts
@@ -103,15 +103,18 @@ describe('ofrepTools', () => {
         context: { targetingKey: 'user-123' },
       });
 
-      expect(mockFetch).toHaveBeenCalledWith('https://flags.example.com/ofrep/v1/evaluate/flags/my-feature', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-          authorization: 'Bearer test-token',
-        },
-        body: JSON.stringify({ context: { targetingKey: 'user-123' } }),
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://flags.example.com/ofrep/v1/evaluate/flags/my-feature',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json',
+            authorization: 'Bearer test-token',
+          },
+          body: JSON.stringify({ context: { targetingKey: 'user-123' } }),
+        }),
+      );
     });
 
     it('should make correct bulk evaluation request', async () => {


### PR DESCRIPTION
## Attempting to fix MCP server hanging in Cursor

Don't have a good reproduction of the issue yet, but these are some suggested fixes after reviewing the codebase. 

### Changes

- **Fix ResourceTemplate `list: undefined`** → `list: async () => ({ resources: [] })` - Cursor may probe resources on startup, and `undefined` caused unexpected behaviour
- **Add fetch timeouts** - 10s for resource fetches, 30s for OFREP API calls using `AbortController`
- **Move `clearTimeout` to `finally`** - ensures timeout covers entire request including body streaming
- **Fix object logging** - `console.error` now properly logs objects instead of `[object Object]`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
