### PR TITLE
feat: enhance OFREP configuration with headers and timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,31 @@ Supports both single flag and bulk evaluation.
 
 To use OFREP flag evaluation features, configure authentication and endpoint details. The server checks configuration in this priority order:
 
-1. **Environment Variables**
-   - `OPENFEATURE_OFREP_BASE_URL` or `OFREP_BASE_URL`
+1. **Tool Arguments**
+   - `base_url`
+   - `auth.bearer_token` / `auth.api_key`
+
+2. **Environment Variables**
+   - `OFREP_ENDPOINT` (preferred) or `OPENFEATURE_OFREP_BASE_URL` / `OFREP_BASE_URL`
+   - `OFREP_HEADERS` (comma-separated `key=value` pairs, URL-decoded before parsing)
+   - `OFREP_TIMEOUT_MS` (positive integer milliseconds)
    - `OPENFEATURE_OFREP_BEARER_TOKEN` or `OFREP_BEARER_TOKEN`
    - `OPENFEATURE_OFREP_API_KEY` or `OFREP_API_KEY`
 
-2. **Configuration File**: `~/.openfeature-mcp.json`
+3. **Configuration File**: `~/.openfeature-mcp.json`
+
+`OFREP_HEADERS` parsing follows the OFREP protocol convention:
+
+- URL-decode the full value first
+- Split by comma into header pairs
+- Split each pair by the first equals sign (`=`)
+- Trim whitespace around keys/values
+- Skip malformed entries
+
+Examples:
+
+- `OFREP_HEADERS=Authorization=Bearer%20token,X-Custom=value`
+- `OFREP_TIMEOUT_MS=5000`
 
 Example `~/.openfeature-mcp.json`:
 
@@ -259,7 +278,11 @@ Example `~/.openfeature-mcp.json`:
   "OFREP": {
     "baseUrl": "https://flags.example.com",
     "bearerToken": "<your-token>",
-    "apiKey": "<your-api-key>"
+    "apiKey": "<your-api-key>",
+    "headers": {
+      "X-Custom-Header": "value"
+    },
+    "timeoutMs": 5000
   }
 }
 ```

--- a/src/tools/ofrepTools.test.ts
+++ b/src/tools/ofrepTools.test.ts
@@ -42,10 +42,13 @@ describe('ofrepTools', () => {
     // Clear environment variables
     delete process.env.OPENFEATURE_OFREP_BASE_URL;
     delete process.env.OFREP_BASE_URL;
+    delete process.env.OFREP_ENDPOINT;
     delete process.env.OPENFEATURE_OFREP_BEARER_TOKEN;
     delete process.env.OFREP_BEARER_TOKEN;
     delete process.env.OPENFEATURE_OFREP_API_KEY;
     delete process.env.OFREP_API_KEY;
+    delete process.env.OFREP_HEADERS;
+    delete process.env.OFREP_TIMEOUT_MS;
   });
 
   afterEach(() => {
@@ -257,6 +260,109 @@ describe('ofrepTools', () => {
           }),
         }),
       );
+    });
+
+    it('should prioritize OFREP_ENDPOINT over legacy base URL env vars', async () => {
+      process.env.OPENFEATURE_OFREP_BASE_URL = 'https://legacy-openfeature.example.com';
+      process.env.OFREP_BASE_URL = 'https://legacy-ofrep.example.com';
+      process.env.OFREP_ENDPOINT = 'https://endpoint.example.com';
+
+      await toolHandler({ flag_key: 'test-flag' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://endpoint.example.com/ofrep/v1/evaluate/flags/test-flag',
+        expect.any(Object),
+      );
+    });
+
+    it('should parse OFREP_HEADERS and let env headers override auth/protocol headers', async () => {
+      process.env.OFREP_ENDPOINT = 'https://flags.example.com';
+      process.env.OPENFEATURE_OFREP_BEARER_TOKEN = 'token-from-env-auth';
+      process.env.OFREP_HEADERS =
+        'Authorization=Bearer%20token-from-header,accept=text/plain,X-Custom=value%3Dwith%3Dequals';
+
+      await toolHandler({ flag_key: 'test-flag' });
+
+      const [, fetchOptions] = mockFetch.mock.calls[0] as [string, { headers: Record<string, string> }];
+      const normalizedHeaders = Object.fromEntries(
+        Object.entries(fetchOptions.headers).map(([key, value]) => [key.toLowerCase(), value]),
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://flags.example.com/ofrep/v1/evaluate/flags/test-flag',
+        expect.any(Object),
+      );
+      expect(normalizedHeaders['authorization']).toBe('Bearer token-from-header');
+      expect(normalizedHeaders['accept']).toBe('text/plain');
+      expect(fetchOptions.headers['X-Custom']).toBe('value=with=equals');
+    });
+
+    it('should skip malformed OFREP_HEADERS entries', async () => {
+      process.env.OFREP_ENDPOINT = 'https://flags.example.com';
+      process.env.OFREP_HEADERS = 'X-Good=ok,missing-separator,=empty-key,empty-value=';
+
+      await toolHandler({ flag_key: 'test-flag' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://flags.example.com/ofrep/v1/evaluate/flags/test-flag',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Good': 'ok',
+          }),
+        }),
+      );
+
+      const [, fetchOptions] = mockFetch.mock.calls[0] as [string, { headers: Record<string, string> }];
+      expect(fetchOptions.headers['missing-separator']).toBeUndefined();
+      expect(fetchOptions.headers['']).toBeUndefined();
+      expect(fetchOptions.headers['empty-value']).toBeUndefined();
+    });
+
+    it('should let OFREP_HEADERS override If-None-Match on collisions', async () => {
+      process.env.OFREP_ENDPOINT = 'https://flags.example.com';
+      process.env.OFREP_HEADERS = 'If-None-Match=override-etag';
+
+      await toolHandler({
+        context: { targetingKey: 'user-123' },
+        etag: 'request-etag',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://flags.example.com/ofrep/v1/evaluate/flags',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'If-None-Match': 'override-etag',
+          }),
+        }),
+      );
+    });
+
+    it('should use OFREP_TIMEOUT_MS when valid', async () => {
+      process.env.OFREP_ENDPOINT = 'https://flags.example.com';
+      process.env.OFREP_TIMEOUT_MS = '1234';
+
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      try {
+        await toolHandler({ flag_key: 'test-flag' });
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1234);
+      } finally {
+        setTimeoutSpy.mockRestore();
+      }
+    });
+
+    it('should fall back to default timeout when OFREP_TIMEOUT_MS is invalid', async () => {
+      process.env.OFREP_ENDPOINT = 'https://flags.example.com';
+      process.env.OFREP_TIMEOUT_MS = 'invalid-timeout';
+
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      try {
+        await toolHandler({ flag_key: 'test-flag' });
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
+      } finally {
+        setTimeoutSpy.mockRestore();
+      }
     });
 
     it('should return error when no base URL configured', async () => {

--- a/src/tools/ofrepTools.test.ts
+++ b/src/tools/ofrepTools.test.ts
@@ -279,7 +279,7 @@ describe('ofrepTools', () => {
       process.env.OFREP_ENDPOINT = 'https://flags.example.com';
       process.env.OPENFEATURE_OFREP_BEARER_TOKEN = 'token-from-env-auth';
       process.env.OFREP_HEADERS =
-        'Authorization=Bearer%20token-from-header,accept=text/plain,X-Custom=value%3Dwith%3Dequals';
+        'Authorization=Bearer%20token-from-header,accept=text/plain,X-Custom=value%3Dwith%3Dequals,X-List=one%2Ctwo%2Cthree';
 
       await toolHandler({ flag_key: 'test-flag' });
 
@@ -295,6 +295,7 @@ describe('ofrepTools', () => {
       expect(normalizedHeaders['authorization']).toBe('Bearer token-from-header');
       expect(normalizedHeaders['accept']).toBe('text/plain');
       expect(fetchOptions.headers['X-Custom']).toBe('value=with=equals');
+      expect(fetchOptions.headers['X-List']).toBe('one,two,three');
     });
 
     it('should skip malformed OFREP_HEADERS entries', async () => {

--- a/src/tools/ofrepTools.ts
+++ b/src/tools/ofrepTools.ts
@@ -5,7 +5,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 
-const FETCH_TIMEOUT_MS = 30 * 1000;
+const DEFAULT_FETCH_TIMEOUT_MS = 30 * 1000;
 
 const OFREPArgsSchema = z.object({
   base_url: z
@@ -46,6 +46,8 @@ const OFREPConfigSchema = z.object({
   baseUrl: z.string().min(1),
   bearerToken: z.string().optional(),
   apiKey: z.string().optional(),
+  headers: z.record(z.string()).optional(),
+  timeoutMs: z.number().int().positive().optional(),
 });
 
 const ConfigFileSchema = z.object({
@@ -67,18 +69,91 @@ async function readConfigFromFile() {
   }
 }
 
+function parseTimeoutMs(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.error(`Invalid OFREP_TIMEOUT_MS value "${value}", falling back to default timeout.`);
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function parseOFREPHeaders(value: string | undefined): Record<string, string> {
+  if (!value || value.trim().length === 0) {
+    return {};
+  }
+
+  let decoded = value;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    console.error('Failed to URL-decode OFREP_HEADERS value. Falling back to raw value parsing.');
+  }
+
+  const parsedHeaders: Record<string, string> = {};
+  for (const headerPart of decoded.split(',')) {
+    const pair = headerPart.trim();
+    if (pair.length === 0) {
+      continue;
+    }
+
+    const separator = pair.indexOf('=');
+    if (separator < 0) {
+      console.error(`Skipping malformed OFREP_HEADERS entry "${pair}": missing '=' separator.`);
+      continue;
+    }
+
+    const key = pair.slice(0, separator).trim();
+    const valuePart = pair.slice(separator + 1).trim();
+
+    if (key.length === 0) {
+      console.error(`Skipping malformed OFREP_HEADERS entry "${pair}": empty header key.`);
+      continue;
+    }
+
+    if (valuePart.length === 0) {
+      console.error(`Skipping malformed OFREP_HEADERS entry "${pair}": empty header value.`);
+      continue;
+    }
+
+    parsedHeaders[key] = valuePart;
+  }
+
+  return parsedHeaders;
+}
+
+function setHeaderCaseInsensitive(headers: Record<string, string>, key: string, value: string) {
+  const keyLower = key.toLowerCase();
+  for (const existingKey of Object.keys(headers)) {
+    if (existingKey.toLowerCase() === keyLower) {
+      delete headers[existingKey];
+    }
+  }
+
+  headers[key] = value;
+}
+
 async function resolveConfig(args: OFREPArgs) {
-  const envBase = process.env.OPENFEATURE_OFREP_BASE_URL ?? process.env.OFREP_BASE_URL;
+  const envBase = process.env.OFREP_ENDPOINT ?? process.env.OPENFEATURE_OFREP_BASE_URL ?? process.env.OFREP_BASE_URL;
   const envBearer = process.env.OPENFEATURE_OFREP_BEARER_TOKEN ?? process.env.OFREP_BEARER_TOKEN;
   const envApiKey = process.env.OPENFEATURE_OFREP_API_KEY ?? process.env.OFREP_API_KEY;
+  const envHeaders = parseOFREPHeaders(process.env.OFREP_HEADERS);
+  const envTimeoutMs = parseTimeoutMs(process.env.OFREP_TIMEOUT_MS);
 
   const fileCfg = await readConfigFromFile();
 
   const baseUrl = args.base_url ?? envBase ?? fileCfg?.baseUrl;
   const bearerToken = args.auth?.bearer_token ?? envBearer ?? fileCfg?.bearerToken;
   const apiKey = args.auth?.api_key ?? envApiKey ?? fileCfg?.apiKey;
+  const headers = Object.keys(envHeaders).length > 0 ? envHeaders : fileCfg?.headers;
+  const timeoutMs = envTimeoutMs ?? fileCfg?.timeoutMs;
 
-  return OFREPConfigSchema.parse({ baseUrl, bearerToken, apiKey });
+  return OFREPConfigSchema.parse({ baseUrl, bearerToken, apiKey, headers, timeoutMs });
 }
 
 /**
@@ -97,12 +172,18 @@ async function callOFREPApi(cfg: OFREPConfig, parsed: OFREPArgs): Promise<CallTo
   };
 
   if (cfg.bearerToken) {
-    headers['authorization'] = `Bearer ${cfg.bearerToken}`;
+    setHeaderCaseInsensitive(headers, 'authorization', `Bearer ${cfg.bearerToken}`);
   } else if (cfg.apiKey) {
-    headers['X-API-Key'] = cfg.apiKey;
+    setHeaderCaseInsensitive(headers, 'X-API-Key', cfg.apiKey);
   }
   if (!isSingleFlagEval && parsed.etag) {
-    headers['If-None-Match'] = parsed.etag;
+    setHeaderCaseInsensitive(headers, 'If-None-Match', parsed.etag);
+  }
+
+  if (cfg.headers) {
+    for (const [key, value] of Object.entries(cfg.headers)) {
+      setHeaderCaseInsensitive(headers, key, value);
+    }
   }
 
   const body = JSON.stringify({
@@ -111,7 +192,8 @@ async function callOFREPApi(cfg: OFREPConfig, parsed: OFREPArgs): Promise<CallTo
 
   console.error(`Fetching OFREP API, url: ${url}, body: ${body}`);
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const timeoutMs = cfg.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetch(url, {
       method: 'POST',

--- a/src/tools/ofrepTools.ts
+++ b/src/tools/ofrepTools.ts
@@ -88,15 +88,8 @@ function parseOFREPHeaders(value: string | undefined): Record<string, string> {
     return {};
   }
 
-  let decoded = value;
-  try {
-    decoded = decodeURIComponent(value);
-  } catch {
-    console.error('Failed to URL-decode OFREP_HEADERS value. Falling back to raw value parsing.');
-  }
-
   const parsedHeaders: Record<string, string> = {};
-  for (const headerPart of decoded.split(',')) {
+  for (const headerPart of value.split(',')) {
     const pair = headerPart.trim();
     if (pair.length === 0) {
       continue;
@@ -108,8 +101,18 @@ function parseOFREPHeaders(value: string | undefined): Record<string, string> {
       continue;
     }
 
-    const key = pair.slice(0, separator).trim();
-    const valuePart = pair.slice(separator + 1).trim();
+    const encodedKey = pair.slice(0, separator).trim();
+    const encodedValue = pair.slice(separator + 1).trim();
+
+    let key = encodedKey;
+    let valuePart = encodedValue;
+    try {
+      key = decodeURIComponent(encodedKey).trim();
+      valuePart = decodeURIComponent(encodedValue).trim();
+    } catch {
+      console.error(`Skipping malformed OFREP_HEADERS entry "${pair}": invalid URL encoding.`);
+      continue;
+    }
 
     if (key.length === 0) {
       console.error(`Skipping malformed OFREP_HEADERS entry "${pair}": empty header key.`);


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request introduces improvements to OFREP flag evaluation configuration, focusing on enhanced environment variable support, custom header parsing, and timeout handling. The changes clarify configuration priority, add robust parsing for headers and timeouts, and ensure environment variables can override protocol and authentication settings.

Configuration enhancements:

* Updated configuration priority: tool arguments now take precedence over environment variables, which in turn take precedence over config files. Added support for `OFREP_ENDPOINT`, `OFREP_HEADERS`, and `OFREP_TIMEOUT_MS` environment variables, with detailed parsing and examples in `README.md`.
* Expanded config file schema (`~/.openfeature-mcp.json`) to support custom headers and timeout values (`headers`, `timeoutMs`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L262-R285) [[2]](diffhunk://#diff-c00d42056d250d9822cf066fd9f40cb322b8cbc3a2936c4cebb7e2923484493dR49-R50)

Header and timeout parsing improvements:

* Added robust parsing logic for `OFREP_HEADERS`, including URL-decoding, handling malformed entries, and overriding protocol/auth headers with environment headers. Introduced `parseOFREPHeaders` and `setHeaderCaseInsensitive` functions for header normalization.
* Implemented parsing for `OFREP_TIMEOUT_MS`, falling back to default timeout if invalid, and applied this value when making API requests. [[1]](diffhunk://#diff-c00d42056d250d9822cf066fd9f40cb322b8cbc3a2936c4cebb7e2923484493dR72-R156) [[2]](diffhunk://#diff-c00d42056d250d9822cf066fd9f40cb322b8cbc3a2936c4cebb7e2923484493dL114-R196)

Testing updates:

* Enhanced tests in `src/tools/ofrepTools.test.ts` to verify new environment variable behaviors, header parsing, malformed entry handling, header overrides, and timeout selection logic. [[1]](diffhunk://#diff-b07b499347569ed3548ecd66b8578e91ef9c131555fb437c5d5b24adc46208a9R265-R367) [[2]](diffhunk://#diff-b07b499347569ed3548ecd66b8578e91ef9c131555fb437c5d5b24adc46208a9R45-R51)

These changes improve flexibility and reliability for OFREP flag evaluation, making configuration and overrides more predictable and robust.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #47