### PR TITLE
feat: add Agent Skills for OpenFeature SDK installation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "openfeature",
+  "description": "OpenFeature SDK installation guides for multiple languages and frameworks, with provider documentation for 35+ feature flag vendors.",
+  "version": "1.0.0",
+  "author": {
+    "name": "OpenFeature",
+    "url": "https://openfeature.dev"
+  },
+  "repository": "https://github.com/open-feature/mcp",
+  "homepage": "https://openfeature.dev",
+  "license": "Apache-2.0"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "npm run build-providers && npm run build-prompts && tsc",
+    "build": "npm run build-providers && npm run build-prompts && tsc && npm run build-skills",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -17,6 +17,7 @@
     "start": "node dist/cli.js",
     "build-prompts": "node scripts/build-prompts.js",
     "build-providers": "node scripts/build-providers.js",
+    "build-skills": "node scripts/build-skills.js",
     "prepack": "npm run build",
     "test": "vitest run"
   },

--- a/scripts/build-skills.js
+++ b/scripts/build-skills.js
@@ -1,0 +1,453 @@
+#!/usr/bin/env node
+
+/**
+ * Script to generate Agent Skills (SKILL.md files) from prompts/*.md and provider data.
+ *
+ * For each technology prompt, this script:
+ * 1. Reads the prompt markdown
+ * 2. Fetches provider documentation URLs (reusing logic from build-providers.js)
+ * 3. Generates a SKILL.md with:
+ *    - YAML frontmatter (name, description, license, metadata)
+ *    - Updated prerequisites with vendor selection prompt
+ *    - The InMemoryProvider default (PROVIDERS block stripped to its content)
+ *    - A Provider Documentation Reference table at the end
+ * 4. Writes to skills/openfeature-<technology>/SKILL.md
+ *
+ * The generated skills are committed to Git (not git-ignored).
+ *
+ * Usage:
+ *   node scripts/build-skills.js                    # build all technologies
+ *   node scripts/build-skills.js nodejs react        # build specific technologies only
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PROMPTS_DIR = path.join(__dirname, '..', 'prompts');
+const SKILLS_DIR = path.join(__dirname, '..', 'skills');
+
+// Technology display names and SDK references for descriptions
+const TECHNOLOGY_META = {
+  dotnet: { displayName: '.NET', sdkName: '.NET SDK' },
+  go: { displayName: 'Go', sdkName: 'Go SDK' },
+  java: { displayName: 'Java', sdkName: 'Java SDK' },
+  javascript: { displayName: 'Web (JavaScript/TypeScript)', sdkName: 'Web SDK' },
+  kotlin: { displayName: 'Kotlin', sdkName: 'Kotlin SDK' },
+  nestjs: { displayName: 'NestJS', sdkName: 'NestJS SDK' },
+  nodejs: { displayName: 'Node.js', sdkName: 'Node.js SDK' },
+  php: { displayName: 'PHP', sdkName: 'PHP SDK' },
+  python: { displayName: 'Python', sdkName: 'Python SDK' },
+  react: { displayName: 'React', sdkName: 'React SDK' },
+  ruby: { displayName: 'Ruby', sdkName: 'Ruby SDK' },
+  swift: { displayName: 'Swift', sdkName: 'Swift SDK' },
+};
+
+// ---- Provider data fetching (reused from build-providers.js) ----
+
+import ts from 'typescript';
+
+const ALLOWED_TECHNOLOGIES = [
+  'kotlin',
+  'dotnet',
+  'go',
+  'swift',
+  'java',
+  'javascript',
+  'nestjs',
+  'nodejs',
+  'php',
+  'python',
+  'react',
+  'ruby',
+];
+
+const techToTechnologyMap = { '.net': 'dotnet' };
+
+function getJavaScriptTechnologyByCategory(category) {
+  if (Array.isArray(category)) {
+    if (category.includes('Server')) return 'nodejs';
+    if (category.includes('Client')) return 'javascript';
+  }
+  return 'javascript';
+}
+
+function getGithubHeaders() {
+  const headers = {
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'openfeature-mcp-build-script',
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+async function fetchProviderDirectoryListing() {
+  const apiUrl = 'https://api.github.com/repos/open-feature/openfeature.dev/contents/src/datasets/providers?ref=main';
+  const res = await fetch(apiUrl, { headers: getGithubHeaders() });
+  if (!res.ok) {
+    throw new Error(`GitHub API error ${res.status}: ${await res.text()}`);
+  }
+  const data = await res.json();
+  return data.filter((entry) => entry.type === 'file' && entry.name.endsWith('.ts'));
+}
+
+async function fetchRemoteProviderFile(downloadUrl) {
+  const res = await fetch(downloadUrl, { headers: { 'User-Agent': 'openfeature-mcp-build-script' } });
+  if (!res.ok) {
+    console.warn(`  Could not fetch provider file from ${downloadUrl}: ${res.status}`);
+    return null;
+  }
+  return await res.text();
+}
+
+function extractDocsUrlByTech(fileContent) {
+  const byTech = {};
+  const sf = ts.createSourceFile('provider.ts', fileContent, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+
+  function getStringLiteralValue(node) {
+    return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node) ? node.text : null;
+  }
+
+  function asObjectLiteral(node) {
+    return ts.isParenthesizedExpression(node) && ts.isObjectLiteralExpression(node.expression)
+      ? node.expression
+      : ts.isObjectLiteralExpression(node)
+        ? node
+        : null;
+  }
+
+  function findTechnologiesArray(obj) {
+    if (!obj) return null;
+    for (const prop of obj.properties) {
+      if (ts.isPropertyAssignment(prop)) {
+        const nameText =
+          ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name) ? prop.name.text.toLowerCase() : '';
+        if (nameText === 'technologies' && ts.isArrayLiteralExpression(prop.initializer)) {
+          return prop.initializer;
+        }
+      }
+    }
+    return null;
+  }
+
+  function visit(node) {
+    if (
+      ts.isVariableStatement(node) &&
+      node.modifiers &&
+      node.modifiers.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const decl of node.declarationList.declarations) {
+        const obj = asObjectLiteral(decl.initializer);
+        if (!obj) continue;
+        const techArr = findTechnologiesArray(obj);
+        if (!techArr) continue;
+
+        for (const el of techArr.elements) {
+          if (!ts.isObjectLiteralExpression(el)) continue;
+          let techName = null;
+          let href = null;
+          let category = null;
+
+          for (const p of el.properties) {
+            if (!ts.isPropertyAssignment(p)) continue;
+            const key = ts.isIdentifier(p.name) || ts.isStringLiteral(p.name) ? p.name.text.toLowerCase() : '';
+            if (key === 'technology') {
+              techName = getStringLiteralValue(p.initializer)?.toLowerCase();
+            } else if (key === 'href') {
+              href = getStringLiteralValue(p.initializer);
+            } else if (key === 'category' && ts.isArrayLiteralExpression(p.initializer)) {
+              category = [];
+              for (const catEl of p.initializer.elements) {
+                const catValue = getStringLiteralValue(catEl);
+                if (catValue) category.push(catValue);
+              }
+            }
+          }
+
+          if (techName && href) {
+            let technology;
+            if (techName === 'javascript') {
+              technology = getJavaScriptTechnologyByCategory(category);
+            } else {
+              technology = techToTechnologyMap[techName] || (ALLOWED_TECHNOLOGIES.includes(techName) ? techName : null);
+            }
+            if (technology && !byTech[technology]) {
+              byTech[technology] = href;
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return byTech;
+}
+
+async function fetchAllProviderDocs() {
+  console.log('Fetching provider data from GitHub...');
+  const result = {};
+
+  try {
+    const listing = await fetchProviderDirectoryListing();
+    for (const entry of listing) {
+      if (!entry.download_url) continue;
+      const content = await fetchRemoteProviderFile(entry.download_url);
+      if (!content) continue;
+
+      const base = path.basename(entry.name, '.ts');
+      if (base === 'index') continue;
+
+      const docsUrlByTechnology = extractDocsUrlByTech(content);
+      if (Object.keys(docsUrlByTechnology).length === 0) continue;
+
+      result[base] = docsUrlByTechnology;
+    }
+  } catch (err) {
+    console.warn('Failed to fetch providers from GitHub:', err?.message || err);
+  }
+
+  console.log(`Fetched documentation URLs for ${Object.keys(result).length} providers.\n`);
+  return result;
+}
+
+// ---- Skill generation ----
+
+/**
+ * Get the list of provider names that support a given technology,
+ * along with their documentation URLs.
+ */
+function getProvidersForTechnology(allProviderDocs, technology) {
+  const providers = [];
+  for (const [providerName, techDocs] of Object.entries(allProviderDocs)) {
+    if (techDocs[technology]) {
+      providers.push({ name: providerName, url: techDocs[technology] });
+    }
+  }
+  providers.sort((a, b) => a.name.localeCompare(b.name));
+  return providers;
+}
+
+/**
+ * Transform the prompt markdown into a SKILL.md.
+ *
+ * - Strips the PROVIDERS markers and keeps the InMemoryProvider content as the default
+ * - Rewrites the prerequisites section to include active vendor selection
+ * - Appends the provider documentation reference table
+ */
+function transformPromptToSkill(promptContent, technology, providers) {
+  const meta = TECHNOLOGY_META[technology] || { displayName: technology, sdkName: `${technology} SDK` };
+
+  // 1. Keep the InMemoryProvider block content, strip the markers
+  const providersMarkerPattern = /<!--\s*PROVIDERS:START\s*-->\n?([\s\S]*?)<!--\s*PROVIDERS:END\s*-->\n?/;
+  let content = promptContent.replace(providersMarkerPattern, '$1');
+
+  // 2. Rewrite the prerequisites section to add vendor selection
+  const providerNames = providers.map((p) => p.name);
+  const vendorSelectionBlock = buildVendorSelectionBlock(meta.displayName, providerNames);
+  content = injectVendorSelection(content, vendorSelectionBlock);
+
+  // 3. Fix cross-references from prompt filenames to skill names
+  content = fixCrossReferences(content);
+
+  // 4. Collapse runs of 3+ blank lines into 2
+  content = content.replace(/\n{3,}/g, '\n\n');
+
+  // 5. Build the provider documentation reference table
+  const providerTable = buildProviderReferenceTable(meta.displayName, providers);
+
+  // 6. Assemble the full SKILL.md
+  const frontmatter = buildFrontmatter(technology, meta);
+  const trimmedContent = content.replace(/\n+$/, '');
+  const trimmedTable = providerTable.replace(/^\n+/, '').replace(/\n+$/, '');
+  return `${frontmatter}\n${trimmedContent}\n\n${trimmedTable}\n`;
+}
+
+/**
+ * Replace prompt-file cross-references (e.g. "use `javascript.md` instead")
+ * with skill name references.
+ */
+function fixCrossReferences(content) {
+  const fileToSkill = {};
+  for (const tech of Object.keys(TECHNOLOGY_META)) {
+    fileToSkill[`${tech}.md`] = `openfeature-${tech}`;
+  }
+
+  // Match patterns like `javascript.md` or `react.md` in backticks
+  return content.replace(/`(\w+)\.md`/g, (match, name) => {
+    const skillName = fileToSkill[`${name}.md`];
+    return skillName ? `the \`${skillName}\` skill` : match;
+  });
+}
+
+function buildFrontmatter(technology, meta) {
+  // Description should be specific enough for agents to match, under 250 chars for Claude Code
+  const description =
+    `Install and configure the OpenFeature ${meta.sdkName} in a ${meta.displayName} application. ` +
+    `Use when adding feature flags or setting up a feature flag provider.`;
+
+  return `---
+name: openfeature-${technology}
+description: >-
+  ${description}
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---`;
+}
+
+function buildVendorSelectionBlock(displayName, providerNames) {
+  if (providerNames.length === 0) {
+    return `
+### Provider Selection
+
+No pre-built providers are currently listed for ${displayName}. Use the example InMemoryProvider in Step 2, or search the web for "<vendor-name> OpenFeature ${displayName} provider" if the user has a specific vendor in mind.
+`;
+  }
+
+  // Format names into wrapped lines for readability
+  const namesWrapped = wrapNames(providerNames, 80);
+
+  return `
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for ${displayName}:
+
+**Available providers:**
+${namesWrapped}
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature ${displayName} provider" to find installation documentation.
+`;
+}
+
+/**
+ * Wrap a list of names into lines of roughly maxWidth characters.
+ */
+function wrapNames(names, maxWidth) {
+  const lines = [];
+  let currentLine = '';
+  for (const name of names) {
+    const separator = currentLine ? ', ' : '';
+    if (currentLine && (currentLine + separator + name).length > maxWidth) {
+      lines.push(currentLine + ',');
+      currentLine = name;
+    } else {
+      currentLine += separator + name;
+    }
+  }
+  if (currentLine) lines.push(currentLine);
+  return lines.join('\n');
+}
+
+/**
+ * Inject the vendor selection block into the prerequisites section.
+ *
+ * Strategy: find the </prerequisites> closing tag and insert just before it.
+ * If no </prerequisites> tag exists, find the "## Installation Steps" heading
+ * and insert before it.
+ */
+function injectVendorSelection(content, vendorSelectionBlock) {
+  // Remove the existing passive provider checkbox lines from prerequisites
+  const providerCheckboxPatterns = [
+    /- \[ \] Do you want to install any provider\(s\).*?\n/g,
+    /- \[ \] Whether to install a provider now;.*?\n/g,
+    /- \[ \] Do you want to combine multiple providers.*?\n/g,
+  ];
+  let cleaned = content;
+  for (const pattern of providerCheckboxPatterns) {
+    cleaned = cleaned.replace(pattern, '');
+  }
+
+  // Insert before </prerequisites> if it exists
+  if (cleaned.includes('</prerequisites>')) {
+    return cleaned.replace('</prerequisites>', `${vendorSelectionBlock}\n</prerequisites>`);
+  }
+
+  // Fallback: insert before "## Installation Steps"
+  const installStepsPattern = /^## Installation Steps/m;
+  if (installStepsPattern.test(cleaned)) {
+    return cleaned.replace(installStepsPattern, `${vendorSelectionBlock}\n## Installation Steps`);
+  }
+
+  // Last resort: append before the first ## heading after prerequisites
+  return cleaned + '\n' + vendorSelectionBlock;
+}
+
+function buildProviderReferenceTable(displayName, providers) {
+  if (providers.length === 0) {
+    return '';
+  }
+
+  const rows = providers.map((p) => `| ${p.name} | ${p.url} |`).join('\n');
+
+  return `
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+${rows}
+`;
+}
+
+// ---- Main ----
+
+async function main() {
+  // Parse CLI arguments for optional technology filter
+  const filterTechnologies = process.argv.slice(2);
+
+  // Fetch provider data
+  const allProviderDocs = await fetchAllProviderDocs();
+
+  // Read available prompt files
+  const promptFiles = await fs.readdir(PROMPTS_DIR);
+  const technologies = promptFiles
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .map((f) => f.replace('.md', ''))
+    .filter((t) => filterTechnologies.length === 0 || filterTechnologies.includes(t))
+    .sort();
+
+  if (technologies.length === 0) {
+    console.log('No matching technologies found.');
+    process.exit(0);
+  }
+
+  console.log(`Building skills for: ${technologies.join(', ')}\n`);
+
+  for (const technology of technologies) {
+    const promptPath = path.join(PROMPTS_DIR, `${technology}.md`);
+    const promptContent = await fs.readFile(promptPath, 'utf-8');
+
+    const providers = getProvidersForTechnology(allProviderDocs, technology);
+    const skillContent = transformPromptToSkill(promptContent, technology, providers);
+
+    const skillDir = path.join(SKILLS_DIR, `openfeature-${technology}`);
+    await fs.mkdir(skillDir, { recursive: true });
+
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(skillPath, skillContent, 'utf-8');
+
+    console.log(`  openfeature-${technology}/SKILL.md (${providers.length} providers)`);
+  }
+
+  console.log(`\nGenerated ${technologies.length} skill(s) in ${path.relative(process.cwd(), SKILLS_DIR)}/`);
+}
+
+main().catch((err) => {
+  console.error('Error building skills:', err);
+  process.exit(1);
+});

--- a/skills/openfeature-dotnet/SKILL.md
+++ b/skills/openfeature-dotnet/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: openfeature-dotnet
+description: >-
+  Install and configure the OpenFeature .NET SDK in a .NET application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature .NET SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature .NET SDK for a server-side .NET application.
+
+Your approach should be:
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and entry point before proceeding
+- Adaptive: offer alternatives when standard approaches fail
+- Conservative: do not create feature flags unless explicitly requested by the user
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature .NET SDK in a server application. If no provider is specified, use an example in-memory provider to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature .NET SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- Browser-based apps (use client SDKs instead)
+- Mobile apps (Android/iOS)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] .NET 8+ is installed (or .NET Framework 4.6.2+)
+- [ ] Your project type (Console, ASP.NET Core, etc.) and entry point
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for .NET:
+
+**Available providers:**
+configcat, devcycle, featbit, flagd, flagsmith, goff, growthbook, hyphen,
+kameleoon, launchdarkly, multi-provider, ofrep, split, statsig, tggl, vwo
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature .NET provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature .NET SDK
+
+Initialize a project and add the package:
+
+```bash
+dotnet new console
+dotnet add package OpenFeature
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+- [ ] Package added successfully
+- [ ] Project builds after restore
+</verification_checkpoint>
+
+### Step 2: Set up OpenFeature with the example in-memory provider
+
+Initialize early and set the example in-memory provider. Replace with a real provider from the OpenFeature ecosystem when ready.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenFeature;
+using OpenFeature.Model;
+
+public class Program
+{
+  public static async Task Main()
+  {
+    try
+    {
+      // Example in-memory flag configuration
+      var variants = new Dictionary<string, bool> {
+        { "on", true },
+        { "off", false }
+      };
+
+      var flags = new Dictionary<string, Flag<bool>> {
+        { "new-message", new Flag<bool>(variants, "on") }
+      };
+
+      var provider = new InMemoryProvider(flags);
+
+      // Replace with a real provider from: https://openfeature.dev/ecosystem/
+      await Api.Instance.SetProviderAsync(provider);
+    }
+    catch (Exception ex)
+    {
+      Console.Error.WriteLine(ex);
+      return;
+    }
+
+    // Create a client for evaluations
+    var client = Api.Instance.GetClient("my-app");
+
+    // Example evaluation without additional context
+    bool enabled = await client.GetBooleanValueAsync("new-message", false);
+  }
+}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+- [ ] Provider set via `await Api.Instance.SetProviderAsync(...)`
+- [ ] App builds and starts without OpenFeature errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable targeting.
+
+```csharp
+using OpenFeature;
+using OpenFeature.Model;
+
+// Set global context (e.g., environment/region)
+var apiCtx = EvaluationContext.Builder()
+  .Set("region", "us-east-1")
+  .Build();
+Api.Instance.SetContext(apiCtx);
+
+// Set client-level context
+var client = Api.Instance.GetClient("my-app");
+var clientCtx = EvaluationContext.Builder()
+  .Set("version", "1.4.6")
+  .Build();
+client.SetContext(clientCtx);
+
+// Per-invocation/request context (recommended)
+var requestCtx = EvaluationContext.Builder()
+  .Set("targetingKey", "user-123")
+  .Set("email", "user@example.com")
+  .Set("ip", "203.0.113.1")
+  .Build();
+bool flagValue = await client.GetBooleanValueAsync("some-flag", false, requestCtx);
+```
+
+### Step 4: Evaluate flags with the client
+
+```csharp
+using OpenFeature;
+using OpenFeature.Model;
+using System.Collections.Generic;
+
+var client = Api.Instance.GetClient("my-app");
+
+// Without additional context
+bool enabled = await client.GetBooleanValueAsync("new-message", false);
+
+// With per-request context (recommended)
+string userId = "user-123";
+var ctx = EvaluationContext.Builder()
+  .Set("targetingKey", userId)
+  .Set("email", "user@example.com")
+  .Build();
+
+string text = await client.GetStringValueAsync("welcome-text", "Hello", ctx);
+int limit = await client.GetIntegerValueAsync("api-limit", 100, ctx);
+
+// Object value (Structure)
+var defaultStructure = new Structure(new Dictionary<string, Value>
+{
+  { "theme", new Value("light") }
+});
+Structure config = await client.GetObjectValueAsync("ui-config", defaultStructure, ctx);
+```
+
+<success_criteria>
+## Installation Success Criteria
+- ✅ OpenFeature .NET SDK installed
+- ✅ Provider initialized via `SetProviderAsync(...)`
+- ✅ Application builds and runs without errors
+- ✅ Evaluation context can be set and used in evaluations
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Dependency Injection (ASP.NET Core)
+
+```csharp
+// Program.cs (.NET 8)
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenFeature(options =>
+{
+  options.AddInMemoryProvider();
+});
+
+var app = builder.Build();
+app.Run();
+```
+
+Reference: [Dependency Injection (OpenFeature .NET SDK)](https://openfeature.dev/docs/reference/technologies/server/dotnet#dependency-injection)
+
+### Multi-Provider
+
+The Multi-Provider enables the use of multiple underlying feature flag providers simultaneously, allowing different providers to be used for different flag keys or based on specific evaluation strategies.
+
+```csharp
+using OpenFeature.Providers.MultiProvider;
+using OpenFeature.Providers.MultiProvider.Models;
+using OpenFeature.Providers.MultiProvider.Strategies;
+
+// Create provider entries
+var providerEntries = new List<ProviderEntry>
+{
+    new(new InMemoryProvider(provider1Flags), "Provider1"),
+    new(new InMemoryProvider(provider2Flags), "Provider2")
+};
+
+// Create multi-provider with FirstMatchStrategy (default)
+var multiProvider = new MultiProvider(providerEntries, new FirstMatchStrategy());
+
+// Set as the default provider
+await Api.Instance.SetProviderAsync(multiProvider);
+
+// Use normally - the multi-provider will handle delegation
+var client = Api.Instance.GetClient();
+var flagValue = await client.GetBooleanValueAsync("my-flag", false);
+```
+
+Reference: [Multi-Provider (OpenFeature .NET SDK)](https://openfeature.dev/docs/reference/technologies/server/dotnet#multi-provider)
+
+### Logging
+
+```csharp
+using Microsoft.Extensions.Logging;
+using OpenFeature;
+using OpenFeature.Hooks;
+
+using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+var logger = loggerFactory.CreateLogger("Program");
+
+var client = Api.Instance.GetClient();
+client.AddHooks(new LoggingHook(logger));
+```
+
+Reference: [Logging (OpenFeature .NET SDK)](https://openfeature.dev/docs/reference/technologies/server/dotnet#logging)
+
+### Shutdown
+
+```csharp
+using OpenFeature;
+
+Api.Instance.Shutdown();
+```
+
+Reference: [Shutdown (OpenFeature .NET SDK)](https://openfeature.dev/docs/reference/technologies/server/dotnet#shutdown)
+
+<troubleshooting>
+## Troubleshooting
+- **.NET version**: Ensure .NET 8+ (or .NET Framework 4.6.2+).
+- **Provider not ready / values are defaults**: Await `SetProviderAsync(...)` and evaluate after initialization.
+- **Context not applied**: Pass an `EvaluationContext` with a `targetingKey`; set global/client contexts for shared values.
+- **NuGet issues**: Clear cache (`dotnet nuget locals all --clear`) and check package sources/versions.
+</troubleshooting>
+
+<next_steps>
+## Next steps
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example in-memory provider.
+- Add flags with `client.Get<Type>ValueAsync` methods and wire business logic to feature decisions.
+- Consider using dependency injection and multi-provider for advanced scenarios.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature .NET SDK docs: [OpenFeature .NET SDK](https://openfeature.dev/docs/reference/technologies/server/dotnet)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| configcat | https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.ConfigCat |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/dotnet/dotnet-openfeature |
+| featbit | https://github.com/featbit/openfeature-provider-dotnet-server |
+| flagd | https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.Flagd |
+| flagsmith | https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.Flagsmith |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_dotnet |
+| growthbook | https://github.com/growthbook/growthbook-openfeature-provider-dot-net |
+| hyphen | https://github.com/Hyphen/openfeature-provider-dotnet |
+| kameleoon | https://github.com/Kameleoon/openfeature-dotnet |
+| launchdarkly | https://github.com/launchdarkly/openfeature-dotnet-server |
+| multi-provider | https://github.com/open-feature/dotnet-sdk/tree/main/src/OpenFeature.Providers.MultiProvider |
+| ofrep | https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Providers.Ofrep |
+| split | https://github.com/splitio/split-openfeature-provider-dotnet |
+| statsig | https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.Statsig |
+| tggl | https://tggl.io/developers/sdks/open-feature/dotnet |
+| vwo | https://github.com/wingify/vwo-openfeature-provider-dotnet |

--- a/skills/openfeature-go/SKILL.md
+++ b/skills/openfeature-go/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: openfeature-go
+description: >-
+  Install and configure the OpenFeature Go SDK in a Go application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature Go SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature Go SDK for a server-side Go application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and entry point before proceeding
+- Adaptive: offer alternatives when standard approaches fail
+- Conservative: do not create feature flags unless explicitly requested by the user
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature Go SDK in a server-side app. If no provider is specified, default to the simple example in-memory provider to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature Go SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- Browser-based apps (use client SDKs instead)
+- Mobile apps (Android/iOS)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Go 1.23+ is installed
+- [ ] Go modules are enabled
+- [ ] Which file is your application entry point (e.g., `cmd/server/main.go`)?
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Go:
+
+**Available providers:**
+awsssm, bucketeer, cloudbees, confidence, configcat, devcycle, env-var, flagd,
+flagsmith, flipswitch, flipt, goff, growthbook, harness, hyphen, kameleoon,
+launchdarkly, mdb-rules, ofrep, posthog, prefab, split, statsig, unleash, vwo
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Go provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature Go SDK
+
+Install the Go SDK module.
+
+```bash
+go get github.com/open-feature/go-sdk
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Dependency fetched successfully
+- [ ] `go.mod` updated with `github.com/open-feature/go-sdk`
+</verification_checkpoint>
+
+### Step 2: Set up OpenFeature with the example in-memory provider
+
+Initialize OpenFeature early in application startup and set the example in-memory provider.
+
+```go
+package main
+
+import (
+    "context"
+
+    "github.com/open-feature/go-sdk/openfeature"
+    "github.com/open-feature/go-sdk/openfeature/memprovider"
+)
+
+func main() {
+    flagConfig := map[string]memprovider.InMemoryFlag{
+        "new-message": {
+            State:          memprovider.Enabled,
+            Variants:       map[string]any{"on": true, "off": false},
+            DefaultVariant: "on",
+        },
+    }
+
+    // Replace with a real provider from: https://openfeature.dev/ecosystem/
+    provider := memprovider.NewInMemoryProvider(flagConfig)
+
+    // Prefer waiting for readiness at startup
+    if err := openfeature.SetProviderAndWait(provider); err != nil {
+        panic(err)
+    }
+
+    // Create a client for evaluations
+    client := openfeature.NewClient("my-app")
+
+    // Example evaluation without additional context
+    _, _ = client.BooleanValue(context.Background(), "new-message", false, openfeature.EvaluationContext{})
+}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider created and set via `openfeature.SetProviderAndWait(...)`
+- [ ] Application builds without OpenFeature import errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable targeting of your feature flags.
+
+```go
+import (
+    "github.com/open-feature/go-sdk/openfeature"
+)
+
+// Set global context (e.g., environment/region)
+openfeature.SetEvaluationContext(openfeature.NewTargetlessEvaluationContext(map[string]any{
+    "region": "us-east-1",
+}))
+
+// Set client-level context
+client := openfeature.NewClient("my-app")
+client.SetEvaluationContext(openfeature.NewTargetlessEvaluationContext(map[string]any{
+    "version": "1.4.6",
+}))
+
+// Create a per-invocation context (recommended)
+evalCtx := openfeature.NewEvaluationContext(
+    "user-123", // targetingKey
+    map[string]any{
+        "email": "user@example.com",
+        "ip":    "203.0.113.1",
+    },
+)
+```
+
+### Step 4: Evaluate flags with the client
+
+Create a client and evaluate feature flag values.
+
+```go
+import (
+    "context"
+    "github.com/open-feature/go-sdk/openfeature"
+)
+
+client := openfeature.NewClient("my-app")
+
+// Without additional context
+enabled, err := client.BooleanValue(
+    context.Background(),
+    "new-message",
+    false,
+    openfeature.EvaluationContext{},
+)
+
+// With per-request context (recommended)
+requestCtx := openfeature.NewEvaluationContext(
+    "user-123",
+    map[string]any{
+        "email": "user@example.com",
+    },
+)
+
+text, _ := client.StringValue(context.Background(), "welcome-text", "Hello", requestCtx)
+limit, _ := client.FloatValue(context.Background(), "api-limit", 100.0, requestCtx)
+config, _ := client.ObjectValue(context.Background(), "ui-config", map[string]any{"theme": "light"}, requestCtx)
+```
+
+<success_criteria>
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature Go SDK installed
+- ✅ Provider set and ready
+- ✅ Application builds and runs without OpenFeature-related errors
+- ✅ Evaluation context can be set and read without errors
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Logging
+
+Attach a logging hook to emit detailed evaluation logs using slog.
+
+```go
+import (
+    "log/slog"
+    "os"
+
+    "github.com/open-feature/go-sdk/openfeature"
+    "github.com/open-feature/go-sdk/openfeature/hooks"
+    "github.com/open-feature/go-sdk/openfeature/memprovider"
+)
+
+// Register an in-memory provider (empty flags are fine)
+_ = openfeature.SetProviderAndWait(memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{}))
+
+handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
+logger := slog.New(handler)
+
+loggingHook := hooks.NewLoggingHook(false, logger)
+openfeature.AddHooks(loggingHook)
+```
+
+Reference: [Logging (OpenFeature Go SDK)](https://openfeature.dev/docs/reference/technologies/server/go#logging)
+
+### Tracking
+
+Associate user actions with feature flag evaluations to support experimentation and analytics.
+
+```go
+import (
+    "context"
+    "github.com/open-feature/go-sdk/openfeature"
+)
+
+client := openfeature.NewClient("my-app")
+
+// Evaluate a flag, then track an event related to its usage
+enabled, _ := client.BooleanValue(context.Background(), "new-feature", false, openfeature.EvaluationContext{})
+if enabled {
+    client.Track(
+        context.Background(),
+        "new-feature-used",
+        openfeature.EvaluationContext{},
+        openfeature.NewTrackingEventDetails(1).Add("source", "example"),
+    )
+}
+```
+
+Reference: [Tracking (OpenFeature Go SDK)](https://openfeature.dev/docs/reference/technologies/server/go#tracking)
+
+### Shutdown
+
+Gracefully clean up all registered providers on application shutdown.
+
+```go
+import "github.com/open-feature/go-sdk/openfeature"
+
+openfeature.Shutdown()
+```
+
+Reference: [Shutdown (OpenFeature Go SDK)](https://openfeature.dev/docs/reference/technologies/server/go#shutdown)
+
+### Transaction Context Propagation
+
+Set and propagate transaction-specific evaluation context (e.g., within an HTTP request) so it is applied automatically during evaluations.
+
+```go
+import (
+    "context"
+    "github.com/open-feature/go-sdk/openfeature"
+)
+
+// Set the transaction context
+ctx := openfeature.WithTransactionContext(context.Background(), openfeature.EvaluationContext{})
+
+// Retrieve or merge as needed
+_ = openfeature.TransactionContext(ctx)
+tCtx := openfeature.MergeTransactionContext(ctx, openfeature.EvaluationContext{})
+
+// Use the transaction context in an evaluation
+_, _ = openfeature.NewClient("my-app").BooleanValue(tCtx, "new-message", false, openfeature.EvaluationContext{})
+```
+
+Reference: [Transaction Context Propagation (OpenFeature Go SDK)](https://openfeature.dev/docs/reference/technologies/server/go#transaction-context-propagation)
+
+<troubleshooting>
+## Troubleshooting
+
+- **Go version**: Ensure Go 1.23+ is used per the SDK requirements.
+- **Provider not ready / values are defaults**: Call `openfeature.SetProviderAndWait(...)` at startup and evaluate flags after initialization.
+- **Context not applied**: Pass an evaluation context with a `targetingKey` for per-request evaluations; use `openfeature.SetEvaluationContext(...)` for global values.
+- **Module issues**: Run `go mod tidy` to resolve dependency metadata and imports.
+</troubleshooting>
+
+<next_steps>
+
+## Next steps
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example in-memory provider.
+- Add flags with `client.<Type>` methods and wire business logic to feature decisions.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature Go SDK docs: [OpenFeature Go SDK](https://openfeature.dev/docs/reference/technologies/server/go)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| awsssm | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/aws-ssm |
+| bucketeer | https://github.com/bucketeer-io/openfeature-go-server-sdk |
+| cloudbees | https://github.com/rollout/cloudbees-openfeature-provider-go |
+| confidence | https://github.com/spotify/confidence-sdk-go |
+| configcat | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/configcat |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/go/go-openfeature |
+| env-var | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/from-env |
+| flagd | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/flagd |
+| flagsmith | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/flagsmith |
+| flipswitch | https://github.com/flipswitch-io/go-sdk |
+| flipt | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/flipt |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_go |
+| growthbook | https://github.com/growthbook/growthbook-openfeature-provider-go |
+| harness | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/harness |
+| hyphen | https://github.com/Hyphen/openfeature-provider-go |
+| kameleoon | https://github.com/Kameleoon/openfeature-go |
+| launchdarkly | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/launchdarkly |
+| mdb-rules | https://github.com/ZackarySantana/mongo-openfeature-go |
+| ofrep | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/ofrep |
+| posthog | https://github.com/dhaus67/openfeature-posthog-go |
+| prefab | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/prefab |
+| split | https://github.com/splitio/split-openfeature-provider-go |
+| statsig | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/statsig |
+| unleash | https://github.com/open-feature/go-sdk-contrib/tree/main/providers/unleash |
+| vwo | https://github.com/wingify/vwo-openfeature-provider-go |

--- a/skills/openfeature-java/SKILL.md
+++ b/skills/openfeature-java/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: openfeature-java
+description: >-
+  Install and configure the OpenFeature Java SDK in a Java application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature Java SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature Java SDK for a server-side Java application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm Java version and build system before proceeding
+- Adaptive: offer Maven and Gradle alternatives
+- Conservative: do not create feature flags or install third‑party providers unless explicitly requested
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature Java SDK in a server application. If no provider is specified, default to the example in-memory provider to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature Java SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- Browser-based apps (use client SDKs instead)
+- Android/mobile apps (use the Android/Kotlin SDK)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Java 11+ is installed
+- [ ] Build tool (Maven or Gradle)
+- [ ] Application entry point (e.g., `src/main/java/.../Main.java` or Spring Boot)
+
+Reference: OpenFeature Java SDK docs [OpenFeature Java SDK](https://openfeature.dev/docs/reference/technologies/server/java)
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Java:
+
+**Available providers:**
+cloudbees, confidence, configcat, datadog, devcycle, env-var, featbit, flagd,
+flagsmith, flipswitch, flipt, goff, growthbook, hyphen, kameleoon, launchdarkly,
+multi-provider, ofrep, split, statsig, unleash, vwo
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Java provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Add the OpenFeature Java SDK dependency
+
+Add the SDK dependency to your project.
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>dev.openfeature</groupId>
+  <artifactId>sdk</artifactId>
+  <version>1.17.0</version>
+  </dependency>
+```
+
+Gradle:
+
+```groovy
+dependencies {
+  implementation 'dev.openfeature:sdk:1.17.0'
+}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Dependency added successfully
+- [ ] Build system synced (Maven/Gradle)
+- [ ] No dependency conflicts
+</verification_checkpoint>
+
+### Step 2: Initialize OpenFeature with the example in-memory provider
+
+Initialize OpenFeature early in application startup and set the example in-memory provider. Replace with a real provider from the OpenFeature ecosystem when ready.
+
+```java
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.Flag;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.providers.memory.InMemoryProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Main {
+  public static void main(String[] args) {
+    Map<String, Flag<?>> flags = new HashMap<>();
+    flags.put("new-message", Flag.builder()
+        .variant("on", true)
+        .variant("off", false)
+        .defaultVariant("on")
+        .build());
+    InMemoryProvider provider = new InMemoryProvider(flags);
+
+    OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+    try {
+      api.setProviderAndWait(provider);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    Client client = api.getClient("my-app");
+    boolean enabled = client.getBooleanValue("new-message", false);
+  }
+}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider is initialized without errors
+- [ ] SDK compiles and application starts
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable targeting of your feature flags.
+
+```java
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.ImmutableContext;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Value;
+
+import java.util.HashMap;
+import java.util.Map;
+
+OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+
+Map<String, Value> apiAttrs = new HashMap<>();
+apiAttrs.put("region", new Value("us-east-1"));
+api.setEvaluationContext(new ImmutableContext(apiAttrs));
+
+Map<String, Value> clientAttrs = new HashMap<>();
+clientAttrs.put("version", new Value("1.4.6"));
+Client client = api.getClient("my-app");
+client.setEvaluationContext(new ImmutableContext(clientAttrs));
+
+Map<String, Value> reqAttrs = new HashMap<>();
+reqAttrs.put("email", new Value("user@example.com"));
+reqAttrs.put("ip", new Value("203.0.113.1"));
+String targetingKey = "user-123";
+EvaluationContext requestCtx = new ImmutableContext(targetingKey, reqAttrs);
+boolean flagValue = client.getBooleanValue("some-flag", false, requestCtx);
+```
+
+### Step 4: Evaluate flags with the client
+
+Create a client and evaluate feature flag values.
+
+```java
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Structure;
+import dev.openfeature.sdk.Value;
+
+Client client = OpenFeatureAPI.getInstance().getClient("my-app");
+
+boolean enabled = client.getBooleanValue("new-message", false);
+
+String userId = "user-123";
+Map<String, Value> attrs = new HashMap<>();
+attrs.put("email", new Value("user@example.com"));
+EvaluationContext ctx = new ImmutableContext(userId, attrs);
+
+String text = client.getStringValue("welcome-text", "Hello", ctx);
+int limit = client.getIntegerValue("api-limit", 100, ctx);
+
+Map<String, Value> defaultMap = new HashMap<>();
+defaultMap.put("theme", new Value("light"));
+Structure defaultValue = new Structure(defaultMap);
+Value obj = client.getObjectValue("ui-config", defaultValue, ctx);
+```
+
+<success_criteria>
+
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ Dependency is added (Maven/Gradle)
+- ✅ Provider is initialized via `setProviderAndWait`
+- ✅ App builds and runs without OpenFeature errors
+- ✅ Evaluation context can be set and read without errors
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Logging
+
+```java
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.contrib.hooks.logging.LoggingHook;
+
+OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+api.addHooks(new LoggingHook());
+```
+
+Reference: [Logging (OpenFeature Java SDK)](https://openfeature.dev/docs/reference/technologies/server/java#logging)
+
+### Tracking
+
+```java
+import dev.openfeature.sdk.MutableTrackingEventDetails;
+import dev.openfeature.sdk.OpenFeatureAPI;
+
+OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+api.getClient().track("visited-promo-page", new MutableTrackingEventDetails(99.77).add("currency", "USD"));
+```
+
+Reference: [Tracking (OpenFeature Java SDK)](https://openfeature.dev/docs/reference/technologies/server/java#tracking)
+
+### Shutdown
+
+```java
+import dev.openfeature.sdk.OpenFeatureAPI;
+
+OpenFeatureAPI.getInstance().shutdown();
+```
+
+Reference: [Shutdown (OpenFeature Java SDK)](https://openfeature.dev/docs/reference/technologies/server/java#shutdown)
+
+### Transaction Context Propagation
+
+```java
+import dev.openfeature.sdk.*;
+import dev.openfeature.sdk.contrib.transaction.ThreadLocalTransactionContextPropagator;
+
+OpenFeatureAPI.getInstance().setTransactionContextPropagator(new ThreadLocalTransactionContextPropagator());
+
+Map<String, Value> txAttrs = new HashMap<>();
+txAttrs.put("userId", new Value("user-123"));
+EvaluationContext txCtx = new ImmutableContext(txAttrs);
+OpenFeatureAPI.getInstance().setTransactionContext(txCtx);
+```
+
+Reference: [Transaction Context Propagation (OpenFeature Java SDK)](https://openfeature.dev/docs/reference/technologies/server/java#transaction-context-propagation)
+
+<troubleshooting>
+## Troubleshooting
+
+- **Java version**: Ensure Java 11+ is used per the SDK requirements.
+- **Provider not ready / values are defaults**: Call `setProviderAndWait(...)` at startup and evaluate flags after initialization.
+- **Context not applied**: Pass an `EvaluationContext` with a targeting key for per-request evaluations; use global/client context setters for shared values.
+- **Build/dependency issues**: Verify repository access, sync dependencies, and ensure versions are compatible (Maven/Gradle refresh).
+</troubleshooting>
+
+<next_steps>
+
+## Next steps
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example in-memory provider.
+- Add flags with `client.get<Type>Value` methods and wire business logic to feature decisions.
+</next_steps>
+
+## Helpful Resources
+
+- OpenFeature Java SDK docs: [OpenFeature Java SDK](https://openfeature.dev/docs/reference/technologies/server/java)
+- OpenFeature ecosystem providers: [Ecosystem](https://openfeature.dev/ecosystem/)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| cloudbees | https://github.com/rollout/cloudbees-openfeature-provider-java |
+| confidence | https://github.com/spotify/confidence-sdk-java |
+| configcat | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/configcat |
+| datadog | https://docs.datadoghq.com/feature_flags/server/java?tab=gradlegroovy |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/java/java-openfeature |
+| env-var | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/env-var |
+| featbit | https://github.com/featbit/featbit-openfeature-provider-java-server |
+| flagd | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/flagd |
+| flagsmith | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/flagsmith |
+| flipswitch | https://github.com/flipswitch-io/java-sdk |
+| flipt | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/flipt |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_java |
+| growthbook | https://github.com/growthbook/growthbook-openfeature-provider-java |
+| hyphen | https://github.com/Hyphen/openfeature-provider-java |
+| kameleoon | https://github.com/Kameleoon/openfeature-java |
+| launchdarkly | https://github.com/launchdarkly/openfeature-java-server |
+| multi-provider | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/multiprovider |
+| ofrep | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/ofrep |
+| split | https://github.com/splitio/split-openfeature-provider-java |
+| statsig | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/statsig |
+| unleash | https://github.com/open-feature/java-sdk-contrib/tree/main/providers/unleash |
+| vwo | https://github.com/wingify/vwo-openfeature-provider-java |

--- a/skills/openfeature-javascript/SKILL.md
+++ b/skills/openfeature-javascript/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: openfeature-javascript
+description: >-
+  Install and configure the OpenFeature Web SDK in a Web (JavaScript/TypeScript) application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature Web SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature Web SDK for a browser-based JavaScript/TypeScript application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and entry point before proceeding
+- Adaptive: offer alternatives when standard approaches fail
+- Conservative: do not create feature flags unless explicitly requested by the user
+
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature Web SDK in a browser app. If no provider is specified, default to the simple `InMemoryProvider` to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature Web SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- React applications (use the `openfeature-react` skill instead)
+- Node.js/server-side apps (use the Server JavaScript SDK guide)
+- React Native or other non-browser runtimes
+</restrictions>
+
+<prerequisites>
+
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Your package manager (npm, yarn, pnpm)
+- [ ] Which file is your entry point (e.g., `src/main.ts`, `src/index.js`)?
+
+Reference: OpenFeature Web SDK docs [OpenFeature Web SDK](https://openfeature.dev/docs/reference/technologies/client/web).
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Web (JavaScript/TypeScript):
+
+**Available providers:**
+abtasty, bucketeer, confidence, configbee, configcat, datadog, devcycle, featbit,
+flagd, flagsmith, flipt, goff, growthbook, hypertune, hyphen, kameleoon,
+launchdarkly, multi-provider, ofrep, reflag, split, tggl, unleash
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Web (JavaScript/TypeScript) provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature Web SDK
+
+Install the core Web SDK package into your browser app.
+
+```bash
+# npm
+npm install --save @openfeature/web-sdk
+
+# yarn
+yarn add @openfeature/web-sdk
+
+# pnpm
+pnpm add @openfeature/web-sdk
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Packages installed successfully
+- [ ] `package.json` updated with dependencies
+</verification_checkpoint>
+
+### Step 2: Set up OpenFeature with the example InMemoryProvider
+
+Initialize OpenFeature early in app startup and set the example in-memory provider. Optionally await readiness with `OpenFeature.setProviderAndWait(...)` if your app evaluates flags immediately at startup.
+
+```javascript
+import { OpenFeature, InMemoryProvider } from '@openfeature/web-sdk';
+
+const flagConfig = {
+  'new-message': {
+    disabled: false,
+    variants: {
+      on: true,
+      off: false,
+    },
+    defaultVariant: 'on',
+  },
+};
+
+const inMemoryProvider = new InMemoryProvider(flagConfig);
+OpenFeature.setProvider(inMemoryProvider);
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider created and set via `OpenFeature.setProvider(...)`
+- [ ] Application compiles without OpenFeature import errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user attributes via the evaluation context to enable user targeting of your feature flags.
+
+```javascript
+import { OpenFeature } from '@openfeature/web-sdk';
+
+async function onLogin(userId, email) {
+  await OpenFeature.setContext({ targetingKey: userId, email, authenticated: true });
+}
+
+async function onLogout() {
+  await OpenFeature.setContext({ targetingKey: `anon-${Date.now()}`, anonymous: true });
+}
+```
+
+### Step 4: Evaluate flags with the client
+
+Get the OpenFeature client and evaluate feature flag values.
+
+```javascript
+import { OpenFeature } from '@openfeature/web-sdk';
+
+async function run() {
+  const client = OpenFeature.getClient();
+
+  const showNewMessage = await client.getBooleanValue('new-message', false);
+  const text = await client.getStringValue('welcome-text', 'Hello');
+  const limit = await client.getNumberValue('api-limit', 100);
+  const config = await client.getObjectValue('ui-config', { theme: 'light' });
+
+  if (showNewMessage) {
+    console.log('Welcome to the new experience!');
+  }
+  console.log({ text, limit, config });
+}
+
+run();
+```
+
+<success_criteria>
+
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature Web SDK installed
+- ✅ Provider set (using `InMemoryProvider` or a specified provider)
+- ✅ App runs without OpenFeature-related errors
+- ✅ Evaluation context can be set and read without errors
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Multi-Provider (combine multiple providers)
+
+If you want a single OpenFeature client that aggregates multiple providers, use the Multi-Provider. Compose providers in precedence order and pick a strategy (e.g., FirstMatch) to decide which provider's result is used.
+
+- Spec: [Multi-Provider](https://openfeature.dev/specification/appendix-a/#multi-provider)
+- Web package: `@openfeature/multi-provider-web` (see repo for examples)
+
+Install:
+
+```bash
+# npm
+npm install --save @openfeature/multi-provider-web
+
+# yarn
+yarn add @openfeature/multi-provider-web
+
+# pnpm
+pnpm add @openfeature/multi-provider-web
+```
+
+Example:
+
+```javascript
+import { OpenFeature, InMemoryProvider } from '@openfeature/web-sdk';
+import { MultiProvider, FirstMatchStrategy } from '@openfeature/multi-provider-web';
+
+const flagConfig = {
+  'new-message': {
+    disabled: false,
+    variants: { on: true, off: false },
+    defaultVariant: 'on',
+  },
+};
+
+const multiProvider = new MultiProvider(
+  [
+    { provider: new InMemoryProvider(flagConfig), name: 'in-memory' },
+  ],
+  new FirstMatchStrategy()
+);
+
+OpenFeature.setProvider(multiProvider);
+```
+
+### Logging
+
+```javascript
+import { OpenFeature } from '@openfeature/web-sdk';
+
+const logger = console;
+OpenFeature.setLogger(logger);
+
+const client = OpenFeature.getClient();
+client.setLogger(logger);
+```
+
+Reference: [Logging (OpenFeature Web SDK)](https://openfeature.dev/docs/reference/technologies/client/web/#logging)
+
+### Tracking
+
+```javascript
+import { OpenFeature } from '@openfeature/web-sdk';
+
+const client = OpenFeature.getClient();
+const enabled = await client.getBooleanValue('new-feature', false);
+if (enabled) {
+  client.track('new-feature-used');
+}
+client.track('cta-clicked', { cta: 'signup' });
+```
+
+Reference: [Tracking (OpenFeature Web SDK)](https://openfeature.dev/docs/reference/technologies/client/web/#tracking)
+
+### Shutdown
+
+Call `OpenFeature.close()` during your app’s shutdown sequence to gracefully clean up providers.
+
+Reference: [Shutdown (OpenFeature Web SDK)](https://openfeature.dev/docs/reference/technologies/client/web/#shutdown)
+
+<troubleshooting>
+
+## Troubleshooting
+
+- **Provider not ready / values are defaults**: Ensure you set the provider early in app startup and, if needed, `await OpenFeature.setProviderAndWait(...)` before evaluations.
+- **Context not applied**: Ensure you call `OpenFeature.setContext(...)` with a `targetingKey` before evaluations that rely on targeting.
+- **Imports**: Import from `@openfeature/web-sdk` for web/browser apps.
+- **Bundling issues**: Ensure your bundler supports ESM.
+</troubleshooting>
+
+## Helpful resources
+
+- OpenFeature Web SDK docs: [OpenFeature Web SDK](https://openfeature.dev/docs/reference/technologies/client/web)
+
+<next_steps>
+
+## Next steps
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example `InMemoryProvider`.
+- Add more flags and wire UI to feature decisions.
+- Consider using the Multi-Provider to aggregate multiple sources.
+</next_steps>
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| abtasty | https://github.com/flagship-io/openfeature-provider-js-client |
+| bucketeer | https://www.npmjs.com/package/@bucketeer/openfeature-js-client-sdk |
+| confidence | https://github.com/spotify/confidence-sdk-js |
+| configbee | https://github.com/configbee/cb-openfeature-provider-web |
+| configcat | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat-web |
+| datadog | https://docs.datadoghq.com/feature_flags/client/javascript?tab=npm |
+| devcycle | https://docs.devcycle.com/sdk/client-side-sdks/javascript/javascript-openfeature |
+| featbit | https://github.com/featbit/openfeature-provider-js-client |
+| flagd | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flagd-web |
+| flagsmith | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flagsmith-client |
+| flipt | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flipt-web |
+| goff | https://gofeatureflag.org/docs/sdk/client_providers/openfeature_javascript |
+| growthbook | https://docs.growthbook.io/lib/js#openfeature-provider |
+| hypertune | https://www.npmjs.com/package/@hypertune/openfeature-web-provider |
+| hyphen | https://github.com/Hyphen/openfeature-provider-javascript-web |
+| kameleoon | https://github.com/Kameleoon/openfeature-js |
+| launchdarkly | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/launchdarkly-client |
+| multi-provider | https://github.com/open-feature/js-sdk/tree/main/packages/web#multi-provider |
+| ofrep | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/ofrep-web |
+| reflag | https://github.com/reflagcom/javascript/tree/main/packages/openfeature-browser-provider |
+| split | https://github.com/splitio/split-openfeature-provider-web-js |
+| tggl | https://tggl.io/developers/sdks/open-feature/web |
+| unleash | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/unleash-web |

--- a/skills/openfeature-kotlin/SKILL.md
+++ b/skills/openfeature-kotlin/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: openfeature-kotlin
+description: >-
+  Install and configure the OpenFeature Kotlin SDK in a Kotlin application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature Android (Kotlin) SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature Android (Kotlin) client SDK.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: detect environment and build system before proceeding
+- Adaptive: provide alternatives when standard approaches fail
+- Conservative: do not add providers or create feature flags unless explicitly requested
+
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature SDK for client-side Android/Kotlin applications. Keep the scope strictly limited to OpenFeature SDK installation and minimal wiring. If a provider is not specified, demonstrate wiring with a placeholder provider only. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature Android/Kotlin SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+Do not use this for:
+
+- Server-side apps (use a server SDK such as Node.js, Go, Java, .NET)
+- iOS apps (use the Swift SDK)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Android SDK 21+ and JDK 11+
+- [ ] Build system (Gradle Kotlin DSL or Groovy)
+- [ ] Initialization location (`Application`, `MainActivity`, or DI setup)
+- [ ] Desired OpenFeature provider (if none, use placeholder `MyProvider`)
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Kotlin:
+
+**Available providers:**
+bucketeer, confidence, configcat, datadog, devcycle, goff, kameleoon, split
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Kotlin provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Add the OpenFeature Kotlin SDK dependency
+
+Gradle (Groovy):
+
+```groovy
+dependencies {
+    api 'dev.openfeature:kotlin-sdk:0.6.2'
+}
+```
+
+Gradle (Kotlin DSL):
+
+```kotlin
+dependencies {
+    api("dev.openfeature:kotlin-sdk:0.6.2")
+}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Dependency added successfully
+- [ ] Project sync or build succeeds without OpenFeature import errors
+</verification_checkpoint>
+
+### Step 2: Initialize OpenFeature with a provider
+
+Initialize OpenFeature early in app startup and set a provider. Replace `MyProvider()` with a real provider later.
+
+```kotlin
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class MyProvider : dev.openfeature.kotlin.sdk.providers.FeatureProvider {
+  override val hooks = emptyList<dev.openfeature.kotlin.sdk.hooks.Hook<*>>()
+  override val metadata = dev.openfeature.kotlin.sdk.Metadata("my-provider")
+}
+
+fun initializeOpenFeature(scope: CoroutineScope) {
+  scope.launch(Dispatchers.Default) {
+    OpenFeatureAPI.setProviderAndWait(MyProvider())
+    val client = OpenFeatureAPI.getClient("my-app")
+    val enabled = client.getBooleanValue("new-message", default = false)
+  }
+}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider initialized via `OpenFeatureAPI.setProviderAndWait(...)`
+- [ ] Client created after readiness
+- [ ] App compiles without OpenFeature initialization errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+```kotlin
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.Value
+
+val apiCtx: EvaluationContext = ImmutableContext(
+  targetingKey = null,
+  attributes = mutableMapOf(
+    "region" to Value.String("us-east-1")
+  )
+)
+OpenFeatureAPI.setEvaluationContext(apiCtx)
+
+val requestCtx: EvaluationContext = ImmutableContext(
+  targetingKey = "user-123",
+  attributes = mutableMapOf(
+    "email" to Value.String("user@example.com"),
+    "ip" to Value.String("203.0.113.1")
+  )
+)
+```
+
+### Step 4: Evaluate flags with the client
+
+```kotlin
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+
+val client = OpenFeatureAPI.getClient("my-app")
+val enabled = client.getBooleanValue("new-message", default = false)
+val text = client.getStringValue("welcome-text", default = "Hello", context = requestCtx)
+val limit = client.getIntegerValue("api-limit", default = 100, context = requestCtx)
+val config = client.getObjectValue("ui-config", default = Value.String("{\"theme\":\"light\"}"), context = requestCtx)
+```
+
+<success_criteria>
+## Installation Success Criteria
+
+- ✅ Dependency added to Gradle
+- ✅ Provider (placeholder or real) initialized with readiness awaited
+- ✅ Global and per-request evaluation contexts configured
+- ✅ Application builds and runs without errors
+- ✅ Sample evaluations return expected default values
+
+</success_criteria>
+
+## Optional advanced usage (implement when requested)
+
+### Tracking
+
+```kotlin
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.TrackingEventDetails
+import dev.openfeature.kotlin.sdk.ImmutableStructure
+import dev.openfeature.kotlin.sdk.Value
+
+val client = OpenFeatureAPI.getClient()
+client.track(
+  "checkout",
+  TrackingEventDetails(
+    499.99,
+    ImmutableStructure(
+      mapOf(
+        "numberOfItems" to Value.Integer(4),
+        "timeInCheckout" to Value.String("PT3M20S")
+      )
+    )
+  )
+)
+```
+
+### Eventing
+
+```kotlin
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+
+fun observeProviderEvents(scope: CoroutineScope) {
+  scope.launch(Dispatchers.Default) {
+    OpenFeatureAPI.observe().collect {
+      // handle provider events
+    }
+  }
+}
+```
+
+### Shutdown
+
+```kotlin
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+OpenFeatureAPI.shutdown()
+```
+
+<troubleshooting>
+## Troubleshooting
+
+- Provider not ready / default values only: use `OpenFeatureAPI.setProviderAndWait(...)` and evaluate after readiness
+- Context not applied: include a `targetingKey` and attributes in an `EvaluationContext`
+- Coroutines: initialize on a background dispatcher and avoid evaluations before readiness
+- Android/KMP versions: ensure Android SDK 21+ and JDK 11+
+
+</troubleshooting>
+
+<next_steps>
+## Next Steps
+
+- Choose and install a real provider when ready; replace `MyProvider`
+- Wire feature decisions into UI/logic via `client.get<Type>Value` methods
+- Keep this prompt focused on OpenFeature installation; provider-specific steps can be added later on request
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature Android/Kotlin SDK docs: [OpenFeature Android SDK](https://openfeature.dev/docs/reference/technologies/client/kotlin)
+- OpenFeature Specification: [OpenFeature Spec](https://openfeature.dev/specification/)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| bucketeer | https://github.com/bucketeer-io/openfeature-kotlin-client-sdk |
+| confidence | https://github.com/spotify/confidence-sdk-android |
+| configcat | https://github.com/configcat/openfeature-kotlin |
+| datadog | https://docs.datadoghq.com/feature_flags/client/android/ |
+| devcycle | https://docs.devcycle.com/sdk/client-side-sdks/android/android-openfeature |
+| goff | https://gofeatureflag.org/docs/sdk/client_providers/openfeature_android |
+| kameleoon | https://github.com/Kameleoon/openfeature-android |
+| split | https://github.com/splitio/split-openfeature-provider-android |

--- a/skills/openfeature-nestjs/SKILL.md
+++ b/skills/openfeature-nestjs/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: openfeature-nestjs
+description: >-
+  Install and configure the OpenFeature NestJS SDK in a NestJS application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature NestJS SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature NestJS SDK for a server-side NestJS application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and module wiring before proceeding
+- Adaptive: offer alternatives when standard approaches fail
+- Conservative: do not create feature flags or install third-party providers unless explicitly requested
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature NestJS SDK for server-side NestJS applications via the NestJS integration. If no provider is specified, default to the simple `InMemoryProvider` to get started. Keep the scope strictly limited to OpenFeature installation and minimal wiring; do not create any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature NestJS SDK using the NestJS integration and verify basic evaluation flows.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+
+- Plain Node.js applications (use the `openfeature-nodejs` skill instead)
+- Client-side applications (use the `openfeature-javascript` skill or the `openfeature-react` skill)
+- Non-NestJS server frameworks (use the `openfeature-nodejs` skill instead)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Node.js 20+ is installed
+- [ ] NestJS 8+ is used in this project
+- [ ] Your package manager (npm, yarn, pnpm)
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for NestJS:
+
+**Available providers:**
+configcat, devcycle, goff
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature NestJS provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature NestJS SDK
+
+Install the NestJS integration for the OpenFeature Server SDK.
+
+```bash
+# npm
+npm install --save @openfeature/nestjs-sdk
+
+# yarn (install peer deps explicitly)
+yarn add @openfeature/nestjs-sdk @openfeature/server-sdk @openfeature/core
+
+# pnpm (install peer deps explicitly)
+pnpm add @openfeature/nestjs-sdk @openfeature/server-sdk @openfeature/core
+```
+
+Peer dependencies (already present in most NestJS apps): `@nestjs/common`, `@nestjs/core`, and `rxjs`.
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Packages installed successfully (and `@openfeature/core` if using yarn/pnpm)
+- [ ] No peer dependency conflicts
+- [ ] `package.json` updated with dependencies
+</verification_checkpoint>
+
+### Step 2: Set up OpenFeature with the example InMemoryProvider
+
+Register the OpenFeature module in your root `AppModule` and configure an example in-memory flag to verify the wiring.
+
+```typescript
+import { Module } from '@nestjs/common';
+import { OpenFeatureModule, InMemoryProvider } from '@openfeature/nestjs-sdk';
+
+@Module({
+  imports: [
+    OpenFeatureModule.forRoot({
+      defaultProvider: new InMemoryProvider({
+        'new-message': {
+          disabled: false,
+          variants: { on: true, off: false },
+          defaultVariant: 'on',
+        },
+      }),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] `OpenFeatureModule.forRoot` is configured with a `defaultProvider`
+- [ ] Application compiles without OpenFeature import errors
+</verification_checkpoint>
+
+### Step 3: Provide evaluation context (request-scoped)
+
+Configure a request-scoped evaluation context so targeting works per user/request. Use the `contextFactory` option.
+
+```typescript
+import { Module } from '@nestjs/common';
+import { OpenFeatureModule, InMemoryProvider } from '@openfeature/nestjs-sdk';
+import type { Request } from 'express';
+
+@Module({
+  imports: [
+    OpenFeatureModule.forRoot({
+      defaultProvider: new InMemoryProvider({}),
+      contextFactory: (req: Request) => ({
+        targetingKey: (req.headers['x-user-id'] as string) ?? 'anonymous',
+        email: req.headers['x-user-email'] as string | undefined,
+        ipAddress: req.ip,
+      }),
+      // useGlobalInterceptor: true, // default enables context for all routes
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Step 4: Evaluate flags in controllers/services
+
+Inject a client using NestJS DI and evaluate feature flags.
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { OpenFeatureClient, Client } from '@openfeature/nestjs-sdk';
+
+@Injectable()
+export class FeatureFlagsService {
+  constructor(@OpenFeatureClient() private readonly client: Client) {}
+
+  async isNewMessageEnabled(): Promise<boolean> {
+    return this.client.getBooleanValue('new-message', false);
+  }
+}
+```
+
+Or inject evaluation details into route handlers using decorators.
+
+```typescript
+import { Controller, Get } from '@nestjs/common';
+import { BooleanFeatureFlag, EvaluationDetails } from '@openfeature/nestjs-sdk';
+import { map, Observable } from 'rxjs';
+
+@Controller('features')
+export class FeaturesController {
+  @Get('welcome')
+  async welcome(
+    @BooleanFeatureFlag({ flagKey: 'new-message', defaultValue: false })
+    feature: Observable<EvaluationDetails<boolean>>,
+  ) {
+    return feature.pipe(map((d) => (d.value ? 'Welcome to the new experience!' : 'Welcome!')));
+  }
+}
+```
+
+<success_criteria>
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature NestJS SDK installed
+- ✅ Example `InMemoryProvider` configured via `OpenFeatureModule.forRoot`
+- ✅ Application starts without OpenFeature-related errors
+- ✅ Request-scoped `contextFactory` is applied (if configured)
+- ✅ Flag evaluations return expected values
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Multi-Provider (combine multiple providers)
+
+If you want a single OpenFeature client that aggregates multiple providers, use the Multi-Provider. Compose providers in precedence order, then set it as the default provider in the NestJS module.
+
+```typescript
+import { Module } from '@nestjs/common';
+import { OpenFeatureModule } from '@openfeature/nestjs-sdk';
+import { OpenFeature, InMemoryProvider } from '@openfeature/server-sdk';
+import { MultiProvider, FirstMatchStrategy } from '@openfeature/multi-provider';
+
+const multiProvider = new MultiProvider(
+  [
+    { provider: new InMemoryProvider({ /*...flags...*/ }), name: 'in-memory' },
+    // { provider: new SomeOtherProvider({ ... }), name: 'vendor' },
+  ],
+  new FirstMatchStrategy(),
+);
+
+@Module({
+  imports: [
+    OpenFeatureModule.forRoot({
+      defaultProvider: multiProvider,
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Logging
+
+Override default console logging by providing a custom logger globally or per client.
+
+```typescript
+import { OpenFeature } from '@openfeature/server-sdk';
+
+const logger = console;
+OpenFeature.setLogger(logger);
+
+// Or per-client
+const client = OpenFeature.getClient();
+client.setLogger(logger);
+```
+
+### Tracking
+
+Associate user actions with feature flag evaluations to support experimentation and analytics.
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { OpenFeatureClient, Client } from '@openfeature/nestjs-sdk';
+
+@Injectable()
+export class TrackingService {
+  constructor(@OpenFeatureClient() private readonly client: Client) {}
+
+  async trackUsage(): Promise<void> {
+    const enabled = await this.client.getBooleanValue('new-feature', false);
+    if (enabled) {
+      // ... use feature
+      this.client.track('new-feature-used');
+    }
+    this.client.track('checkout-started', { cartValue: 123.45, currency: 'USD' });
+  }
+}
+```
+
+### Shutdown
+
+Gracefully clean up all registered providers on application shutdown (e.g., in a NestJS lifecycle hook).
+
+```typescript
+import { OpenFeature } from '@openfeature/server-sdk';
+
+await OpenFeature.close();
+```
+
+<troubleshooting>
+## Troubleshooting
+
+- **Node.js version**: Ensure Node.js 20+ is used per the SDK requirements.
+- **Provider not ready / values are defaults**: Configure the provider during module initialization and evaluate flags after module setup completes.
+- **Context not applied**: Provide a `contextFactory` (with a `targetingKey`) or pass an explicit evaluation context when calling `get*Value` methods.
+- **Peer dependency with yarn/pnpm**: Install `@openfeature/core` alongside `@openfeature/server-sdk` when using yarn or pnpm.
+</troubleshooting>
+
+<next_steps>
+## Next steps
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example `InMemoryProvider`.
+- Add flags with `client.get<type>Value` methods or route handlers using decorators and wire business logic to feature decisions.
+- Consider using the Multi-Provider to aggregate multiple providers.
+- Consider tracking events with `client.track`.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature NestJS SDK docs: [OpenFeature NestJS SDK](https://openfeature.dev/docs/reference/technologies/server/javascript/nestjs)
+- Multi-Provider (server) contrib: [js-sdk-contrib multi-provider](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| configcat | https://configcat.com/docs/sdk-reference/openfeature/nestjs |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/nestjs/nestjs-openfeature |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_nestjs |

--- a/skills/openfeature-nodejs/SKILL.md
+++ b/skills/openfeature-nodejs/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: openfeature-nodejs
+description: >-
+  Install and configure the OpenFeature Node.js SDK in a Node.js application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature Node.js SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature Node.js SDK for a Node.js server application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and entry point before proceeding
+- Adaptive: offer alternatives when standard approaches fail
+- Conservative: do not create feature flags or install third-party providers unless explicitly requested
+
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature Node.js SDK in a server-side JavaScript/TypeScript application. If no provider is specified, default to the example `InMemoryProvider` to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature Node.js SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+Do not use this for:
+
+- Browser-based apps (use the `openfeature-javascript` skill instead)
+- React applications (use the `openfeature-react` skill instead)
+- React Native apps
+- Non-Node runtimes (Bun / Deno / Cloudflare Workers / etc)
+
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Node.js 18+ is installed
+- [ ] Your package manager (npm, yarn, pnpm)
+- [ ] Which file is your server entry point (e.g., `src/server.ts`, `src/index.js`)?
+
+Reference: OpenFeature Node.js SDK docs [OpenFeature Node.js SDK](https://openfeature.dev/docs/reference/technologies/server/javascript/)
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Node.js:
+
+**Available providers:**
+abtasty, awsssm, bucketeer, cloudbees, confidence, configcat, datadog, devcycle,
+env-var, featbit, flagd, flagsmith, flipt, goff, growthbook, hypertune, hyphen,
+kameleoon, launchdarkly, multi-provider, ofrep, posthog, reflag, split, tggl,
+vercel, vwo
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Node.js provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature Node.js SDK
+
+Install the server SDK package for Node.js.
+
+```bash
+# npm
+npm install --save @openfeature/server-sdk
+
+# yarn (install peer dep explicitly)
+yarn add @openfeature/server-sdk @openfeature/core
+
+# pnpm (install peer dep explicitly)
+pnpm add @openfeature/server-sdk @openfeature/core
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Packages installed successfully
+- [ ] No peer dependency conflicts
+- [ ] `package.json` updated with dependencies
+</verification_checkpoint>
+
+### Step 2: Initialize OpenFeature
+
+Initialize OpenFeature early in server startup and set the example in-memory provider.
+
+```javascript
+import { OpenFeature, InMemoryProvider } from '@openfeature/server-sdk';
+
+const flagConfig = {
+  'new-message': {
+    disabled: false,
+    variants: {
+      on: true,
+      off: false,
+    },
+    defaultVariant: 'on',
+  },
+};
+
+const inMemoryProvider = new InMemoryProvider(flagConfig);
+
+// Prefer awaiting readiness at startup
+await OpenFeature.setProviderAndWait(inMemoryProvider);
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider created and initialized via `await OpenFeature.setProviderAndWait(...)`
+- [ ] Initialization occurs before the server starts handling requests
+- [ ] No OpenFeature initialization errors logged
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable user targeting of your feature flags.
+
+```javascript
+import { OpenFeature, AsyncLocalStorageTransactionContextPropagator } from '@openfeature/server-sdk';
+
+// Set global context (e.g., environment/region)
+OpenFeature.setContext({ region: process.env.REGION || 'us-east-1' });
+
+// Optional: Enable transaction context propagation (Express-style)
+OpenFeature.setTransactionContextPropagator(new AsyncLocalStorageTransactionContextPropagator());
+
+app.use((req, res, next) => {
+  const context = {
+    targetingKey: req.user?.id || 'anonymous',
+    email: req.user?.email,
+    ipAddress: req.get?.('x-forwarded-for') || req.ip,
+  };
+
+  // Apply request-scoped context to subsequent flag evaluations
+  OpenFeature.setTransactionContext(context, () => {
+    next();
+  });
+});
+```
+
+### Step 4: Evaluate flags with the client
+
+Create a client and evaluate feature flag values.
+
+```javascript
+import { OpenFeature } from '@openfeature/server-sdk';
+
+const client = OpenFeature.getClient();
+
+// Without context
+const enabled = await client.getBooleanValue('new-message', false);
+
+// With per-request context (recommended)
+const requestContext = {
+  targetingKey: req.user?.id || 'anonymous',
+  email: req.user?.email,
+};
+
+const text = await client.getStringValue('welcome-text', 'Hello', requestContext);
+const limit = await client.getNumberValue('api-limit', 100, requestContext);
+const config = await client.getObjectValue('ui-config', { theme: 'light' }, requestContext);
+```
+
+<success_criteria>
+
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature Node.js SDK package installed (and `@openfeature/core` with yarn/pnpm)
+- ✅ Provider is configured and initialized via `await OpenFeature.setProviderAndWait(...)`
+- ✅ Server starts without OpenFeature errors
+- ✅ Flag evaluations return expected values after initialization
+</success_criteria>
+
+## Common Installation Scenarios
+
+Scenario: Express.js API, Node.js 18, npm
+
+Actions taken:
+
+1. ✅ Installed `@openfeature/server-sdk`
+2. ✅ Initialized `InMemoryProvider` before server startup
+3. ✅ Set global context and request context
+4. ✅ Evaluated flags in routes
+
+Result: Installation successful
+
+Scenario: Fastify microservice, TypeScript
+
+Actions taken:
+
+1. ✅ Installed packages with TypeScript support
+2. ✅ Created an initialization plugin for OpenFeature
+3. ✅ Registered plugin before routes
+4. ✅ Evaluated flags with proper context
+
+Result: Installation successful with TypeScript
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Multi-Provider (combine multiple providers)
+
+If you want a single OpenFeature client that aggregates multiple providers, use the Multi-Provider. Compose providers in precedence order and pick a strategy (e.g., FirstMatch) to decide which provider's result is used.
+
+- Spec: [Multi-Provider](https://openfeature.dev/specification/appendix-a/#multi-provider)
+- Server package: `@openfeature/multi-provider` ([reference](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider))
+
+Install:
+
+```bash
+# npm
+npm install --save @openfeature/multi-provider
+
+# yarn
+yarn add @openfeature/multi-provider
+
+# pnpm
+pnpm add @openfeature/multi-provider
+```
+
+Example:
+
+```javascript
+import { OpenFeature, InMemoryProvider } from '@openfeature/server-sdk';
+import { MultiProvider, FirstMatchStrategy } from '@openfeature/multi-provider';
+
+const multiProvider = new MultiProvider(
+  [
+    { provider: new InMemoryProvider({ /*...flags...*/ }), name: 'in-memory' },
+    // { provider: new SomeOtherProvider({ ... }), name: 'vendor' },
+  ],
+  new FirstMatchStrategy()
+);
+
+await OpenFeature.setProviderAndWait(multiProvider);
+```
+
+### Logging
+
+Override default console logging by providing a custom logger globally or per client.
+
+```javascript
+import { OpenFeature } from '@openfeature/server-sdk';
+// If using TypeScript, you can type the logger: import type { Logger } from '@openfeature/server-sdk'
+
+const logger = console;
+
+// Set a global logger (applies to all clients unless overridden)
+OpenFeature.setLogger(logger);
+
+// Or set a client-specific logger
+const client = OpenFeature.getClient();
+client.setLogger(logger);
+```
+
+Reference: [Logging (OpenFeature Node.js SDK)](https://openfeature.dev/docs/reference/technologies/server/javascript/#logging)
+
+### Tracking
+
+Associate user actions with feature flag evaluations to support experimentation and analytics. Evaluate a flag, then record relevant events using `client.track`.
+
+```javascript
+import { OpenFeature } from '@openfeature/server-sdk';
+
+const client = OpenFeature.getClient();
+
+const enabled = await client.getBooleanValue('new-feature', false);
+
+if (enabled) {
+  useNewFeature();
+  client.track('new-feature-used');
+}
+
+client.track('checkout-started', { cartValue: 123.45, currency: 'USD' });
+```
+
+Reference: [Tracking (OpenFeature Node.js SDK)](https://openfeature.dev/docs/reference/technologies/server/javascript/#tracking)
+
+### Shutdown
+
+Gracefully clean up all registered providers on application shutdown. Call `OpenFeature.close()` during your shutdown sequence (e.g., on process signals or server close).
+
+Reference: [Shutdown (OpenFeature Node.js SDK)](https://openfeature.dev/docs/reference/technologies/server/javascript/#shutdown)
+
+<troubleshooting>
+
+- **Node.js version**: Ensure Node.js 18+ is used per the SDK requirements.
+- **Provider not ready / values are defaults**: Call `await OpenFeature.setProviderAndWait(...)` at startup and evaluate flags after initialization.
+- **Context not applied**: Pass an evaluation context with a `targetingKey` for per-request evaluations; use `OpenFeature.setContext(...)` for global values.
+- **Peer dependency with yarn/pnpm**: Install `@openfeature/core` alongside `@openfeature/server-sdk` when using yarn or pnpm.
+
+</troubleshooting>
+
+<next_steps>
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example `InMemoryProvider`.
+- Add flags with `client.get<type>Value` methods and wire business logic to feature decisions.
+- Consider using the Multi-Provider to aggregate multiple providers.
+- Consider tracking events with `client.track`.
+
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature Node.js SDK docs: [OpenFeature Node.js SDK](https://openfeature.dev/docs/reference/technologies/server/javascript/)
+- Multi-Provider spec: [Multi-Provider](https://openfeature.dev/specification/appendix-a/#multi-provider)
+- Multi-Provider (server) contrib: [js-sdk-contrib multi-provider](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| abtasty | https://github.com/flagship-io/openfeature-provider-js |
+| awsssm | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/aws-ssm |
+| bucketeer | https://www.npmjs.com/package/@bucketeer/openfeature-node-server-sdk |
+| cloudbees | https://github.com/rollout/cloudbees-openfeature-provider-node |
+| confidence | https://github.com/spotify/confidence-sdk-js |
+| configcat | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat |
+| datadog | https://docs.datadoghq.com/feature_flags/server/nodejs |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature |
+| env-var | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/env-var |
+| featbit | https://github.com/featbit/openfeature-provider-node-server |
+| flagd | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flagd |
+| flagsmith | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flagsmith |
+| flipt | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flipt |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_javascript |
+| growthbook | https://github.com/open-feature/js-sdk-contrib/blob/main/libs/providers/growthbook/README.md |
+| hypertune | https://www.npmjs.com/package/@hypertune/openfeature-server-provider |
+| hyphen | https://github.com/Hyphen/openfeature-provider-javascript-server |
+| kameleoon | https://github.com/Kameleoon/openfeature-nodejs |
+| launchdarkly | https://github.com/launchdarkly/openfeature-node-server |
+| multi-provider | https://github.com/open-feature/js-sdk/tree/main/packages/server#multi-provider |
+| ofrep | https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/ofrep |
+| posthog | https://www.npmjs.com/package/@tapico/node-openfeature-posthog |
+| reflag | https://github.com/reflagcom/javascript/tree/main/packages/openfeature-node-provider |
+| split | https://github.com/splitio/split-openfeature-provider-js |
+| tggl | https://tggl.io/developers/sdks/open-feature/node |
+| vercel | https://vercel.com/docs/flags/vercel-flags/sdks/openfeature |
+| vwo | https://github.com/wingify/vwo-openfeature-provider-node |

--- a/skills/openfeature-php/SKILL.md
+++ b/skills/openfeature-php/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: openfeature-php
+description: >-
+  Install and configure the OpenFeature PHP SDK in a PHP application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature PHP SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature PHP SDK for a server-side PHP application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: detect environment and entry point before proceeding
+- Adaptive: provide alternatives when standard approaches fail
+- Conservative: do not add providers or create feature flags unless explicitly requested
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature PHP SDK for server-side PHP applications. Keep the scope strictly limited to OpenFeature SDK installation and minimal wiring. If a provider is not specified, proceed without one or show a placeholder that can be swapped later. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature PHP SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+Do not use this for:
+
+- Browser-based apps (use client SDKs instead)
+- Mobile apps (Android/iOS)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] PHP 8.0+ is installed
+- [ ] Composer is available
+- [ ] Application entry point (e.g., `public/index.php`, framework bootstrap, or a CLI script)
+- [ ] Desired OpenFeature provider (if none, proceed without a provider or plan to add one later)
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for PHP:
+
+**Available providers:**
+cloudbees, configcat, devcycle, flagd, goff, kameleoon, launchdarkly, split, vwo
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature PHP provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature PHP SDK
+
+Install the SDK via Composer.
+
+```bash
+composer require open-feature/sdk
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Package installed successfully
+- [ ] Autoloader configured (`vendor/autoload.php`)
+</verification_checkpoint>
+
+### Step 2: Initialize OpenFeature
+
+Initialize OpenFeature early in application startup. If you have a provider, set it before creating a client.
+
+```php
+<?php
+use OpenFeature\OpenFeatureAPI;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$api = OpenFeatureAPI::getInstance();
+$client = $api->getClient('my-app');
+
+$enabled = $client->getBooleanValue('new-message', false);
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] API instance retrieved
+- [ ] Client created after initialization
+- [ ] App starts without OpenFeature errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable targeting.
+
+```php
+<?php
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\implementation\flags\EvaluationContext;
+
+$api = OpenFeatureAPI::getInstance();
+$client = $api->getClient('my-app');
+
+$api->setEvaluationContext(new EvaluationContext('system', [
+  'region' => 'us-east-1',
+]));
+
+$client->setEvaluationContext(new EvaluationContext('system', [
+  'version' => '1.4.6',
+]));
+
+$requestCtx = new EvaluationContext('user-123', [
+  'email' => 'user@example.com',
+  'ip' => '203.0.113.1',
+]);
+
+$flagValue = $client->getBooleanValue('some-flag', false, $requestCtx);
+```
+
+### Step 4: Evaluate flags with the client
+
+```php
+<?php
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\implementation\flags\EvaluationContext;
+
+$client = OpenFeatureAPI::getInstance()->getClient('my-app');
+
+$enabled = $client->getBooleanValue('new-message', false);
+
+$ctx = new EvaluationContext('user-123', ['email' => 'user@example.com']);
+
+$text = $client->getStringValue('welcome-text', 'Hello', $ctx);
+$limit = $client->getIntegerValue('api-limit', 100, $ctx);
+$config = $client->getObjectValue('ui-config', [ 'theme' => 'light' ], $ctx);
+```
+
+<success_criteria>
+## Installation Success Criteria
+
+- ✅ OpenFeature PHP SDK installed
+- ✅ Application starts without OpenFeature-related errors
+- ✅ Client can evaluate flags returning default values
+- ✅ Evaluation context can be set and used
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Logging (PSR-3)
+
+```php
+<?php
+use OpenFeature\OpenFeatureAPI;
+
+$api = OpenFeatureAPI::getInstance();
+$api->setLogger($logger);
+
+$client = $api->getClient('custom-logger');
+$client->setLogger($logger);
+```
+
+### Hooks
+
+```php
+<?php
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\implementation\flags\EvaluationContext;
+use OpenFeature\implementation\flags\EvaluationOptions;
+
+$api = OpenFeatureAPI::getInstance();
+$client = $api->getClient('my-app');
+
+$api->addHook(new ExampleGlobalHook());
+$client->addHook(new ExampleClientHook());
+
+$value = $client->getBooleanValue('boolFlag', false, new EvaluationContext('user-123'), new EvaluationOptions([ new ExampleInvocationHook() ]));
+```
+
+<troubleshooting>
+## Troubleshooting
+
+- **PHP version**: Ensure PHP 8.0+ is used per the SDK requirements.
+- **Provider not set / values are defaults**: Set a provider before evaluations if you expect non-default values.
+- **Context not applied**: Pass an `EvaluationContext` with a targeting key for per-request evaluations; set global/client contexts for shared values.
+- **Composer issues**: Run `composer install` / `composer update`, ensure autoloading is configured, and verify namespaces/imports.
+</troubleshooting>
+
+<next_steps>
+## Next steps
+
+- Choose and install a real provider when ready; replace any placeholder wiring.
+- Add flags with `$client->get<Type>Value` methods and wire business logic to feature decisions.
+- Consider configuring a PSR-3 logger and using hooks for observability.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature PHP SDK docs: [OpenFeature PHP SDK](https://openfeature.dev/docs/reference/technologies/server/php)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| cloudbees | https://github.com/open-feature/php-sdk-contrib/tree/main/providers/CloudBees |
+| configcat | https://github.com/configcat/openfeature-php |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/php/php-openfeature |
+| flagd | https://github.com/open-feature/php-sdk-contrib/tree/main/providers/Flagd |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_php |
+| kameleoon | https://github.com/Kameleoon/openfeature-php |
+| launchdarkly | https://github.com/launchdarkly/openfeature-php-server |
+| split | https://github.com/open-feature/php-sdk-contrib/tree/main/providers/Split |
+| vwo | https://github.com/wingify/vwo-openfeature-provider-php |

--- a/skills/openfeature-python/SKILL.md
+++ b/skills/openfeature-python/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: openfeature-python
+description: >-
+  Install and configure the OpenFeature Python SDK in a Python application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature Python SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature Python SDK for a server-side Python application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm Python version and package manager before proceeding
+- Adaptive: provide pip and poetry alternatives
+- Conservative: do not create feature flags or install third‑party providers unless explicitly requested
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature Python SDK in a server application. If no provider is specified, default to the example in-memory provider to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature Python SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- Browser-based apps (use client SDKs instead)
+- Mobile apps (Android/iOS)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Python 3.9+ is installed
+- [ ] Your package manager (pip or poetry)
+- [ ] Which file is your application entry point (e.g., `app.py`, `main.py`, framework bootstrap)?
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Python:
+
+**Available providers:**
+cloudbees, confidence, configcat, datadog, devcycle, flagd, flagsmith,
+flipswitch, flipt, goff, growthbook, hyphen, kameleoon, launchdarkly, ofrep, vwo
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Python provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature Python SDK
+
+Install the SDK with pip (or poetry).
+
+```bash
+# pip
+pip install openfeature-sdk
+
+# poetry
+poetry add openfeature-sdk
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Package installed successfully
+- [ ] Virtual environment active (if used)
+</verification_checkpoint>
+
+### Step 2: Initialize OpenFeature with the example in-memory provider
+
+Initialize OpenFeature early in application startup and set the example in-memory provider. Replace with a real provider from the OpenFeature ecosystem when ready.
+
+```python
+from openfeature import api
+from openfeature.provider.in_memory_provider import InMemoryFlag, InMemoryProvider
+
+# Example in-memory flag configuration
+my_flags = {
+  "new-message": InMemoryFlag("on", {"on": True, "off": False})
+}
+
+# Replace with a real provider from: https://openfeature.dev/ecosystem/
+api.set_provider(InMemoryProvider(my_flags))
+
+# Create a client for evaluations
+client = api.get_client("my-app")
+
+# Example evaluation without additional context
+enabled = client.get_boolean_value("new-message", False)
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider is set without errors
+- [ ] Application starts without OpenFeature import errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable targeting of your feature flags.
+
+```python
+from openfeature import api
+from openfeature.evaluation_context import EvaluationContext
+
+# Set global context (e.g., environment/region)
+api.set_evaluation_context(
+  EvaluationContext(targeting_key="system", attributes={"region": "us-east-1"})
+)
+
+# Create a per-invocation/request context (recommended)
+request_ctx = EvaluationContext(
+  targeting_key="user-123",
+  attributes={
+    "email": "user@example.com",
+    "ip": "203.0.113.1",
+  },
+)
+```
+
+### Step 4: Evaluate flags with the client
+
+Create a client and evaluate feature flag values.
+
+```python
+from openfeature import api
+
+client = api.get_client("my-app")
+
+# Without additional context
+enabled = client.get_boolean_value("new-message", False)
+
+# With per-request context (recommended)
+text = client.get_string_value("welcome-text", "Hello", request_ctx)
+limit = client.get_integer_value("api-limit", 100, request_ctx)
+config = client.get_object_value("ui-config", {"theme": "light"}, request_ctx)
+```
+
+<success_criteria>
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature Python SDK installed
+- ✅ Provider set and usable for evaluations
+- ✅ Application starts without OpenFeature-related errors
+- ✅ Evaluation context can be set and read without errors
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Logging
+
+The SDK logs via the standard `logging` package using the `openfeature` logger.
+
+```python
+import logging
+
+logging.getLogger("openfeature").setLevel(logging.DEBUG)
+```
+
+Reference: [Logging (OpenFeature Python SDK)](https://openfeature.dev/docs/reference/technologies/server/python#logging)
+
+### Transaction Context Propagation
+
+Set and propagate transaction-specific evaluation context so it is automatically applied during evaluations.
+
+```python
+from openfeature import api
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.transaction_context import ContextVarsTransactionContextPropagator
+
+api.set_transaction_context_propagator(ContextVarsTransactionContextPropagator())
+
+api.set_transaction_context(
+  EvaluationContext(targeting_key="user-123", attributes={"ipAddress": "203.0.113.1"})
+)
+```
+
+Reference: [Transaction Context Propagation (OpenFeature Python SDK)](https://openfeature.dev/docs/reference/technologies/server/python#transaction-context-propagation)
+
+### Asynchronous feature retrieval
+
+If your provider supports async, you can evaluate flags asynchronously.
+
+```python
+import asyncio
+from openfeature import api
+from openfeature.provider.in_memory_provider import InMemoryFlag, InMemoryProvider
+
+async def main():
+  my_flags = {"v2_enabled": InMemoryFlag("on", {"on": True, "off": False})}
+  api.set_provider(InMemoryProvider(my_flags))
+  client = api.get_client()
+  value = await client.get_boolean_value_async("v2_enabled", False)
+  print(value)
+
+asyncio.run(main())
+```
+
+Reference: [Asynchronous Feature Retrieval (OpenFeature Python SDK)](https://openfeature.dev/docs/reference/technologies/server/python#asynchronous-feature-retrieval)
+
+### Shutdown
+
+Gracefully clean up registered providers on application shutdown.
+
+```python
+from openfeature import api
+
+api.shutdown()
+```
+
+Reference: [Shutdown (OpenFeature Python SDK)](https://openfeature.dev/docs/reference/technologies/server/python#shutdown)
+
+<troubleshooting>
+## Troubleshooting
+
+- **Python version**: Ensure Python 3.9+ is used per the SDK requirements.
+- **Provider not set / values are defaults**: Call `api.set_provider(...)` before evaluations.
+- **Context not applied**: Pass an `EvaluationContext` with a `targeting_key` for per-request evaluations; set global context for shared values.
+- **Environment issues**: Verify your virtual environment, imports, and package installation (`pip list | grep openfeature`).
+</troubleshooting>
+
+<next_steps>
+## Next steps
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example in-memory provider.
+- Add flags with `client.get_<type>_value` methods and wire business logic to feature decisions.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature Python SDK docs: [OpenFeature Python SDK](https://openfeature.dev/docs/reference/technologies/server/python)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| cloudbees | https://github.com/rollout/cloudbees-openfeature-provider-python |
+| confidence | https://github.com/spotify/confidence-sdk-python |
+| configcat | https://github.com/configcat/openfeature-python |
+| datadog | https://docs.datadoghq.com/feature_flags/server/python |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/python/python-openfeature |
+| flagd | https://github.com/open-feature/python-sdk-contrib/tree/main/providers/openfeature-provider-flagd |
+| flagsmith | https://github.com/Flagsmith/flagsmith-openfeature-provider-python |
+| flipswitch | https://github.com/flipswitch-io/python-sdk |
+| flipt | https://github.com/open-feature/python-sdk-contrib/tree/main/providers/openfeature-provider-flipt |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_python |
+| growthbook | https://github.com/growthbook/growthbook-openfeature-provider-python |
+| hyphen | https://github.com/Hyphen/openfeature-provider-python |
+| kameleoon | https://github.com/Kameleoon/openfeature-python |
+| launchdarkly | https://github.com/launchdarkly/openfeature-python-server |
+| ofrep | https://github.com/open-feature/python-sdk-contrib/tree/main/providers/openfeature-provider-ofrep |
+| vwo | https://github.com/wingify/vwo-openfeature-provider-python |

--- a/skills/openfeature-react/SKILL.md
+++ b/skills/openfeature-react/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: openfeature-react
+description: >-
+  Install and configure the OpenFeature React SDK in a React application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature React SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature and React integration specialist helping a developer install the OpenFeature React SDK for a browser-based React application.
+
+Your approach should be:
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and entry point before proceeding
+- Adaptive: offer alternatives when standard approaches fail
+- Conservative: do not create feature flags unless explicitly requested by the user
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature React SDK in a React web app. If no provider is specified, default to the simple `InMemoryProvider` to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature React SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- Next.js applications (use a Next.js-specific guide)
+- React Native apps (use the React Native SDK instead)
+- Non-React JavaScript applications (use the `openfeature-javascript` skill instead)
+- Server-side React rendering without a browser context
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] React 16.8+ is installed
+- [ ] Your package manager (npm, yarn, pnpm)
+- [ ] Which file is your entry point (`src/main.tsx`, `src/index.tsx`, or `src/App.tsx`)?
+
+Reference: OpenFeature React SDK docs [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/web/react).
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for React:
+
+**Available providers:**
+configcat, datadog, devcycle, goff
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature React provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature React SDK
+
+Install the React SDK and required peer dependencies.
+
+```bash
+# npm
+npm install --save @openfeature/react-sdk
+
+# yarn (install peer deps explicitly)
+yarn add @openfeature/react-sdk @openfeature/web-sdk @openfeature/core
+
+# pnpm (install peer deps explicitly)
+pnpm add @openfeature/react-sdk @openfeature/web-sdk @openfeature/core
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Packages installed successfully
+- [ ] No peer dependency conflicts
+- [ ] `package.json` updated with dependencies
+</verification_checkpoint>
+
+### Step 2: Set up OpenFeature with the example InMemoryProvider
+
+Initialize OpenFeature early and set the example in-memory provider.
+
+Add this to your entry point or `App` component file.
+
+```javascript
+import React from 'react';
+import { OpenFeatureProvider, OpenFeature, InMemoryProvider } from '@openfeature/react-sdk';
+
+const flagConfig = {
+  'new-message': {
+    disabled: false,
+    variants: {
+      on: true,
+      off: false,
+    },
+    defaultVariant: 'on',
+  },
+};
+
+// Replace with provider from: https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5BallTechnologies%5D%5B0%5D=React
+const inMemoryProvider = new InMemoryProvider(flagConfig);
+
+// Optionally await readiness: await OpenFeature.setProviderAndWait(inMemoryProvider);
+OpenFeature.setProvider(inMemoryProvider);
+
+function App() {
+  return (
+    <OpenFeatureProvider>
+      <div className="App">
+        <h1>My React App with OpenFeature</h1>
+      </div>
+    </OpenFeatureProvider>
+  );
+}
+
+export default App;
+```
+
+Note: You do not need to await provider initialization; the React SDK will handle re-rendering and suspense when the provider is ready [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/web/react).
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider created and set via `OpenFeature.setProvider(...)`
+- [ ] `OpenFeatureProvider` wraps your app
+- [ ] Application compiles without OpenFeature import errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user attributes via the evaluation context to enable user targeting of your feature flags.
+
+```javascript
+import { OpenFeature } from '@openfeature/react-sdk';
+
+async function onLogin(userId, email) {
+  await OpenFeature.setContext({ targetingKey: userId, email, authenticated: true });
+}
+
+async function onLogout() {
+  await OpenFeature.setContext({ targetingKey: `anon-${Date.now()}`, anonymous: true });
+}
+```
+
+### Step 4: Evaluate flags with hooks
+
+Optionally, if requested by the user: use React hooks to read feature flags and react to changes.
+
+```javascript
+import { useFlag, useBooleanFlagValue } from '@openfeature/react-sdk';
+
+function Page() {
+  const { value: showNewMessage } = useFlag('new-message', false);
+  const isOn = useBooleanFlagValue('new-message', false);
+
+  return <>{showNewMessage && isOn ? <p>Welcome!</p> : <p>Hello</p>}</>;
+}
+```
+
+<success_criteria>
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature React SDK installed (and peer deps when needed)
+- ✅ Provider set (using `InMemoryProvider` or a specified provider)
+- ✅ `OpenFeatureProvider` wraps the application
+- ✅ App runs without OpenFeature-related errors
+- ✅ Evaluation context can be set and read without errors
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Multi-Provider (combine multiple providers)
+
+If you want a single OpenFeature client that aggregates multiple providers, use the Multi-Provider. Compose providers in precedence order and pick a strategy (e.g., FirstMatch) to decide which provider's result is used.
+
+- Spec: [Multi-Provider](https://openfeature.dev/specification/appendix-a/#multi-provider)
+- Web package: `@openfeature/multi-provider-web` ([reference](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider-web))
+
+Install:
+
+```bash
+# npm
+npm install --save @openfeature/multi-provider-web
+
+# yarn
+yarn add @openfeature/multi-provider-web
+
+# pnpm
+pnpm add @openfeature/multi-provider-web
+```
+
+Example:
+
+```javascript
+import { OpenFeature, InMemoryProvider } from '@openfeature/react-sdk';
+import { MultiProvider, FirstMatchStrategy } from '@openfeature/multi-provider-web';
+
+// Compose providers in precedence order (first match wins)
+const multiProvider = new MultiProvider(
+  [
+    { provider: new InMemoryProvider(flagConfig), name: 'in-memory' },
+    // { provider: new SomeOtherProvider({ ... }), name: 'vendor' }
+  ],
+  new FirstMatchStrategy()
+);
+
+// Optionally await readiness: await OpenFeature.setProviderAndWait(multiProvider);
+OpenFeature.setProvider(multiProvider);
+```
+
+### Re-rendering with context changes
+
+Control whether components re-render when the evaluation context changes (e.g., on login or user attribute updates).
+
+```javascript
+import { useFlag } from '@openfeature/react-sdk';
+
+function Page() {
+  const { value } = useFlag('new-message', false, { updateOnContextChanged: true });
+  return <>{value ? 'New' : 'Old'}</>;
+}
+```
+
+### Re-rendering with flag configuration changes
+
+Control whether components re-render when the underlying provider reports configuration changes (e.g., flags updated remotely).
+
+```javascript
+import { useFlag } from '@openfeature/react-sdk';
+
+function Page() {
+  const { value } = useFlag('new-message', false, { updateOnConfigurationChanged: true });
+  return <>{value ? 'New' : 'Old'}</>;
+}
+```
+
+### Suspense support
+
+Optionally suspend rendering until the provider is ready or during context reconciliation; useful for showing loading states around flag-dependent UI.
+
+```javascript
+import { Suspense } from 'react';
+import { useSuspenseFlag } from '@openfeature/react-sdk';
+
+function Content() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Message />
+    </Suspense>
+  );
+}
+
+function Message() {
+  const { value } = useSuspenseFlag('new-message', false);
+  return <>{value ? <p>Welcome!</p> : <p>Hello</p>}</>;
+}
+```
+
+### Tracking
+
+Associate user actions with flag evaluations using a provider-agnostic tracking API via `useTrack`.
+
+```javascript
+import { useTrack } from '@openfeature/react-sdk';
+
+function MyComponent() {
+  const { track } = useTrack();
+  track('clicked-cta', { cta: 'signup' });
+  return null;
+}
+```
+
+### Testing
+
+Use `OpenFeatureTestProvider` to supply default or explicit flag values and simulate readiness delays in component tests.
+
+```javascript
+import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
+
+// default values only
+<OpenFeatureTestProvider>
+  <MyComponent />
+</OpenFeatureTestProvider>
+
+// control values
+<OpenFeatureTestProvider flagValueMap={{ 'my-boolean-flag': true }}>
+  <MyComponent />
+</OpenFeatureTestProvider>
+```
+
+<troubleshooting>
+- **Suspense boundary error**: Add a `<Suspense>` boundary around components using flags, or disable suspend options in hooks/provider [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/web/react).
+- **Unexpected mount/hide behavior with React 16/17**: Prefer React 18 for Concurrent Suspense, or gate siblings with `useWhenProviderReady`.
+- **Multiple providers share state**: Set a distinct `domain` on each `OpenFeatureProvider`.
+- **Imports**: Import from `@openfeature/react-sdk` (it re-exports web/core).
+</troubleshooting>
+
+<next_steps>
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with `InMemoryProvider`.
+- Add flags and wire UI with `useFlag`/typed hooks.
+- Consider using the Multi-Provider to aggregate multiple providers.
+- Consider tracking events with `useTrack`.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature React SDK docs: [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/web/react)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| configcat | https://configcat.com/docs/sdk-reference/openfeature/react |
+| datadog | https://docs.datadoghq.com/feature_flags/client/react?tab=npm |
+| devcycle | https://docs.devcycle.com/sdk/client-side-sdks/react/react-openfeature |
+| goff | https://gofeatureflag.org/docs/sdk/client_providers/openfeature_react |

--- a/skills/openfeature-ruby/SKILL.md
+++ b/skills/openfeature-ruby/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: openfeature-ruby
+description: >-
+  Install and configure the OpenFeature Ruby SDK in a Ruby application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature Ruby SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature Ruby SDK for a server-side Ruby application.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and entry point before proceeding
+- Adaptive: provide alternatives when standard approaches fail
+- Conservative: do not create feature flags or install third‑party providers unless explicitly requested
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature Ruby SDK in a server application. If no provider is specified, default to the example in-memory provider to get started. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature Ruby SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- Browser-based apps (use client SDKs instead)
+- Mobile apps (Android/iOS)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Ruby 3.1+ is installed (3.1.4/3.2.3/3.3.0 supported)
+- [ ] Your dependency manager (bundler or RubyGems)
+- [ ] Which file is your application entry point (e.g., `config/application.rb`, `app.rb`)?
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Ruby:
+
+**Available providers:**
+configcat, datadog, devcycle, flagsmith, goff, kameleoon, launchdarkly
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Ruby provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature Ruby SDK
+
+Install the gem and add it to your Gemfile.
+
+```bash
+bundle add openfeature-sdk
+```
+
+Or, if not using bundler:
+
+```bash
+gem install openfeature-sdk
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Gem installed and available in your environment
+- [ ] `Gemfile`/lockfile updated (if using bundler)
+</verification_checkpoint>
+
+### Step 2: Initialize OpenFeature with the example in-memory provider
+
+Initialize OpenFeature early in application startup and set the example in-memory provider. Replace with a real provider from the OpenFeature ecosystem when ready.
+
+```ruby
+require 'open_feature/sdk'
+
+OpenFeature::SDK.configure do |config|
+  # Replace with a real provider from: https://openfeature.dev/ecosystem/
+  config.set_provider(
+    OpenFeature::SDK::Provider::InMemoryProvider.new({
+      'new-message' => true,
+    })
+  )
+end
+
+client = OpenFeature::SDK.build_client('my-app')
+
+# Example evaluation without additional context
+enabled = client.fetch_boolean_value(flag_key: 'new-message', default_value: false)
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider is initialized without errors
+- [ ] SDK loads and application starts
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable targeting of your feature flags.
+
+```ruby
+require 'open_feature/sdk'
+
+# Set global (API) context
+OpenFeature::SDK.configure do |config|
+  config.evaluation_context = OpenFeature::SDK::EvaluationContext.new(
+    'region' => 'us-east-1'
+  )
+end
+
+# Set client-level context
+client = OpenFeature::SDK.build_client(
+  'my-app',
+  evaluation_context: OpenFeature::SDK::EvaluationContext.new(
+    'version' => '1.4.6'
+  )
+)
+
+# Create a per-invocation/request context (recommended)
+request_context = OpenFeature::SDK::EvaluationContext.new(
+  'email' => 'user@example.com',
+  'ip' => '203.0.113.1'
+)
+
+# Use the request context in an evaluation
+flag_value = client.fetch_boolean_value(
+  flag_key: 'some-flag',
+  default_value: false,
+  evaluation_context: request_context
+)
+```
+
+### Step 4: Evaluate flags with the client
+
+Create a client and evaluate feature flag values.
+
+```ruby
+require 'open_feature/sdk'
+
+client = OpenFeature::SDK.build_client('my-app')
+
+# Without additional context
+enabled = client.fetch_boolean_value(flag_key: 'new-message', default_value: false)
+
+# With per-request context (recommended)
+ctx = OpenFeature::SDK::EvaluationContext.new('email' => 'user@example.com')
+
+text = client.fetch_string_value(flag_key: 'welcome-text', default_value: 'Hello', evaluation_context: ctx)
+limit = client.fetch_number_value(flag_key: 'api-limit', default_value: 100, evaluation_context: ctx)
+
+# Object/JSON value (pass serialized JSON or a hash depending on provider)
+require 'json'
+config = client.fetch_object_value(
+  flag_key: 'ui-config',
+  default_value: JSON.dump({ theme: 'light' }),
+  evaluation_context: ctx
+)
+```
+
+<success_criteria>
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature Ruby SDK installed
+- ✅ Example in-memory provider configured
+- ✅ Application starts without OpenFeature errors
+- ✅ Evaluation context can be set and read without errors
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Domains
+
+Bind clients to providers by domain.
+
+```ruby
+OpenFeature::SDK.configure do |config|
+  config.set_provider(OpenFeature::SDK::Provider::InMemoryProvider.new({}), domain: 'legacy_flags')
+end
+
+legacy_client = OpenFeature::SDK.build_client('legacy-app', domain: 'legacy_flags')
+```
+
+Reference: [Domains (OpenFeature Ruby SDK)](https://openfeature.dev/docs/reference/technologies/server/ruby#domains)
+
+<troubleshooting>
+## Troubleshooting
+
+- **Ruby version**: Ensure a supported Ruby version (3.1.4/3.2.3/3.3.0) per SDK requirements.
+- **Provider not set / values are defaults**: Configure a provider in `OpenFeature::SDK.configure` before evaluations.
+- **Context not applied**: Pass an `EvaluationContext` to `fetch_*_value` or configure client/global context as shown.
+- **Bundler/RubyGems issues**: Run `bundle install`, verify your `Gemfile`, or `gem list | grep openfeature-sdk` to confirm installation.
+</troubleshooting>
+
+<next_steps>
+## Next steps
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the example in-memory provider.
+- Add flags with `client.fetch_<type>_value` methods and wire business logic to feature decisions.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature Ruby SDK docs: [OpenFeature Ruby SDK](https://openfeature.dev/docs/reference/technologies/server/ruby)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| configcat | https://github.com/configcat/openfeature-ruby |
+| datadog | https://docs.datadoghq.com/feature_flags/server/ruby |
+| devcycle | https://docs.devcycle.com/sdk/server-side-sdks/ruby/ruby-openfeature |
+| flagsmith | https://github.com/open-feature/ruby-sdk-contrib/tree/main/providers/openfeature-flagsmith-provider |
+| goff | https://gofeatureflag.org/docs/sdk/server_providers/openfeature_ruby |
+| kameleoon | https://github.com/Kameleoon/openfeature-ruby |
+| launchdarkly | https://github.com/launchdarkly/openfeature-ruby-server |

--- a/skills/openfeature-swift/SKILL.md
+++ b/skills/openfeature-swift/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: openfeature-swift
+description: >-
+  Install and configure the OpenFeature Swift SDK in a Swift application. Use when adding feature flags or setting up a feature flag provider.
+license: Apache-2.0
+metadata:
+  author: openfeature
+  version: "1.0"
+---
+# OpenFeature iOS SDK Installation Prompt
+
+<role>
+You are an expert OpenFeature integration specialist helping a developer install the OpenFeature iOS (Swift) client SDK.
+
+Your approach should be:
+
+- Methodical: follow steps in order
+- Diagnostic: confirm environment and entry point before proceeding
+- Adaptive: provide alternatives when standard approaches fail
+- Conservative: do not create feature flags unless explicitly requested by the user
+</role>
+
+<context>
+You are helping to install and configure the OpenFeature iOS SDK in a client-side Swift application. If no provider is specified, default to a simple placeholder provider to demonstrate wiring. Do not create or configure any feature flags as part of this process.
+</context>
+
+<task_overview>
+Follow this guide to install and wire up the OpenFeature iOS SDK. Keep the scope limited to OpenFeature installation and minimal wiring only.
+</task_overview>
+
+<restrictions>
+**Do not use this for:**
+- Server-side apps (use a server SDK such as Node.js, Go, Java, .NET)
+- Android apps (use the Kotlin SDK)
+</restrictions>
+
+<prerequisites>
+## Required Information
+
+Before proceeding, confirm:
+
+- [ ] Apple platform targets: iOS 14+, macOS 11+, watchOS 7+, tvOS 14+
+- [ ] Swift 5.5+ and Xcode with SPM or CocoaPods
+- [ ] Initialization location (`AppDelegate`, `SceneDelegate`, or app bootstrap)
+- [ ] Desired provider (if none, use placeholder provider in this guide)
+
+### Provider Selection
+
+Before installing, ask the user which feature flag vendor they would like to use. Present the following list of vendors that have OpenFeature provider support for Swift:
+
+**Available providers:**
+abtasty, bucketeer, confidence, configcat, datadog, devcycle, goff, hyphen,
+kameleoon, split, user-defaults
+
+Ask the user to pick one (or more) from this list, or confirm they want to start with the built-in **InMemoryProvider** for testing and prototyping.
+
+- If the user selects a vendor, look up the vendor's documentation URL in the **Provider Documentation Reference** section at the end of this document, fetch and read the documentation, and use it to configure the provider in Step 2 instead of InMemoryProvider.
+- If the user wants to proceed without a vendor or is unsure, use the example InMemoryProvider shown in Step 2.
+- If the user names a vendor not in the list, search the web for "<vendor-name> OpenFeature Swift provider" to find installation documentation.
+
+</prerequisites>
+
+## Installation Steps
+
+### Step 1: Install the OpenFeature iOS SDK
+
+Swift Package Manager (SPM): in `Package.swift` add the latest version of the `open-feature/swift-sdk` dependency and product.
+
+```swift
+// Package.swift
+dependencies: [
+  .package(url: "https://github.com/open-feature/swift-sdk.git", from: "0.4.0")
+]
+
+// target
+.product(name: "OpenFeature", package: "swift-sdk"),
+```
+
+Or add via Xcode: File > Add Packages... and use `https://github.com/open-feature/swift-sdk.git`.
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Package added via SPM or Pod installed successfully
+- [ ] Project builds after dependency resolution
+</verification_checkpoint>
+
+### Step 2: Initialize OpenFeature with a provider
+
+Initialize OpenFeature early in app startup and set a provider. Replace `CustomProvider()` with a real provider from the OpenFeature ecosystem when ready. Prefer awaiting readiness before evaluating any flags.
+
+```swift
+import OpenFeature
+
+@main
+struct MyApp: App {
+  init() {
+    Task {
+      let provider = CustomProvider() // replace with a real provider
+      await OpenFeatureAPI.shared.setProviderAndWait(provider: provider)
+
+      // Create a client for evaluations
+      let client = OpenFeatureAPI.shared.getClient("my-app")
+
+      // Example evaluation without additional context
+      _ = client.getBooleanValue(key: "new-message", defaultValue: false)
+    }
+  }
+
+  var body: some Scene {
+    WindowGroup { ContentView() }
+  }
+}
+```
+
+<verification_checkpoint>
+**Verify before continuing:**
+
+- [ ] Provider created and set via `setProviderAndWait(...)`
+- [ ] App compiles without OpenFeature import errors
+</verification_checkpoint>
+
+### Step 3: Update the evaluation context
+
+Provide user or environment attributes via the evaluation context to enable targeting of your feature flags.
+
+```swift
+import OpenFeature
+
+// Set global (API) context (e.g., environment/region)
+let ctx = ImmutableContext(
+  targetingKey: nil,
+  structure: ImmutableStructure(attributes: [
+    "region": Value.string("us-east-1")
+  ])
+)
+OpenFeatureAPI.shared.setEvaluationContext(evaluationContext: ctx)
+```
+
+### Step 4: Evaluate flags with the client
+
+Get the client and evaluate feature flag values.
+
+```swift
+import OpenFeature
+
+let client = OpenFeatureAPI.shared.getClient("my-app")
+
+let enabled = client.getBooleanValue(key: "new-message", defaultValue: false)
+let text = client.getStringValue(key: "welcome-text", defaultValue: "Hello")
+let number = client.getNumberValue(key: "api-limit", defaultValue: 100)
+let obj = client.getObjectValue(key: "ui-config", defaultValue: Value.string("{\"theme\":\"light\"}"))
+```
+
+<success_criteria>
+
+## Installation Success Criteria
+
+Installation is complete when ALL of the following are true:
+
+- ✅ OpenFeature iOS SDK installed
+- ✅ Provider set (placeholder or real) and readiness awaited
+- ✅ App builds and runs without errors
+- ✅ Evaluation context can be set and read without errors
+</success_criteria>
+
+## Optional advanced usage
+
+Only implement the following optional sections if requested.
+
+### Hooks
+
+Attach hooks globally or per client to run code before/after evaluations.
+
+```swift
+import OpenFeature
+
+OpenFeatureAPI.shared.addHooks(hooks: ExampleHook())
+
+let client = OpenFeatureAPI.shared.getClient()
+client.addHooks(ExampleHook())
+```
+
+Reference: [Hooks (OpenFeature iOS SDK)](https://openfeature.dev/docs/reference/technologies/client/swift#hooks)
+
+### Eventing
+
+Observe provider events (e.g., readiness or configuration changes).
+
+```swift
+import OpenFeature
+import Combine
+
+var cancellables = Set<AnyCancellable>()
+
+OpenFeatureAPI.shared.observe().sink { event in
+  switch event {
+  case .ready:
+    // provider ready
+    break
+  default:
+    break
+  }
+}.store(in: &cancellables)
+```
+
+Reference: [Eventing (OpenFeature iOS SDK)](https://openfeature.dev/docs/reference/technologies/client/swift#eventing)
+
+<troubleshooting>
+## Troubleshooting
+
+- **Apple platform versions**: Ensure minimum targets (iOS 14+/macOS 11+/watchOS 7+/tvOS 14+).
+- **Provider not ready / values are defaults**: Use `await setProviderAndWait(...)` and evaluate flags after readiness.
+- **Context not applied**: Set a global evaluation context via `setEvaluationContext(...)` before evaluations relying on targeting.
+- **SPM/Pods issues**: Verify package URL/version, or run `pod repo update` and `pod install`.
+</troubleshooting>
+
+<next_steps>
+
+## Next steps
+
+- If you want a real provider, specify which provider(s) to install now; otherwise continue with the placeholder provider and swap later.
+- Add flags with `client.get*Value` methods and wire app logic to feature decisions.
+- Consider using hooks and event observation for extensibility and reactivity.
+</next_steps>
+
+## Helpful resources
+
+- OpenFeature iOS (Swift) SDK docs: [OpenFeature iOS SDK](https://openfeature.dev/docs/reference/technologies/client/swift)
+
+## Provider Documentation Reference
+
+When the user selects a vendor from the list above, find the vendor in this table, then fetch and read the linked documentation. Follow the vendor's instructions to install and configure their OpenFeature provider in place of InMemoryProvider in Step 2.
+
+Browse all providers: https://openfeature.dev/ecosystem
+
+| Provider | Documentation |
+|----------|---------------|
+| abtasty | https://github.com/flagship-io/openfeature-provider-iOS |
+| bucketeer | https://github.com/bucketeer-io/openfeature-swift-client-sdk |
+| confidence | https://github.com/spotify/confidence-sdk-swift |
+| configcat | https://github.com/configcat/openfeature-swift |
+| datadog | https://docs.datadoghq.com/feature_flags/client/ios?tab=swiftpackagemanagerspm |
+| devcycle | https://docs.devcycle.com/sdk/client-side-sdks/ios/ios-openfeature |
+| goff | https://gofeatureflag.org/docs/sdk/client_providers/openfeature_swift |
+| hyphen | https://github.com/Hyphen/hyphen-openfeature-swift |
+| kameleoon | https://github.com/Kameleoon/openfeature-swift |
+| split | https://github.com/splitio/split-openfeature-provider-swift |
+| user-defaults | https://github.com/fumito-ito/UserDefaults-OpenFeature-Provider-Swift |


### PR DESCRIPTION
## Summary

- Add [Agent Skills](https://agentskills.io) (SKILL.md files) for all 12 supported technologies, generated from existing `prompts/*.md`
- Each skill actively prompts the user to select a feature flag vendor from a per-technology provider list before defaulting to InMemoryProvider
- Include a provider documentation reference table in each skill so the agent can fetch vendor-specific installation docs
- Add a Claude Code plugin manifest (`.claude-plugin/plugin.json`) for marketplace distribution

## Motivation

The existing `install_openfeature_sdk` MCP tool requires running an MCP server. Agent Skills are a portable, open standard supported by 30+ AI coding agents (Claude Code, OpenCode, Cursor, Codex, Gemini CLI, GitHub Copilot, Goose, Roo Code, etc.) that work without any server setup. This lets users get OpenFeature installation guidance in any skills-compatible agent by just copying files.

## Implementation

`scripts/build-skills.js` generates `skills/openfeature-<technology>/SKILL.md` from `prompts/*.md` + live provider data fetched from the OpenFeature ecosystem repo. The build script:

1. Reads each prompt markdown file
2. Fetches provider documentation URLs from GitHub (same data source as `build-providers.js`)
3. Strips MCP-specific markers (`PROVIDERS:START/END`), keeping InMemoryProvider content as default
4. Rewrites the prerequisites section to actively prompt users for vendor selection
5. Appends a per-technology provider documentation reference table
6. Fixes cross-references from prompt filenames to skill names

Generated skills are committed to Git so consumers don't need to run a build step.

| Directory | Files | Purpose |
|-----------|-------|---------|
| `scripts/` | 1 added | `build-skills.js` |
| `skills/` | 12 added | One `SKILL.md` per technology |
| `.claude-plugin/` | 1 added | Plugin manifest for Claude Code marketplace |
| `package.json` | modified | Added `build-skills` script |

### Installation

**Claude Code:**
```
/plugin marketplace add open-feature/mcp
```

**Any agent (project-level):**
```bash
cp -r skills/openfeature-* .agents/skills/
```

**Any agent (user-level):**
```bash
cp -r skills/openfeature-* ~/.agents/skills/
```

### Notes

- The MCP server remains the premium experience for dynamic provider injection; skills are a static, portable alternative
- Provider URLs are fetched at build time, so `npm run build-skills` should be re-run when the ecosystem data changes
- Currently focused on reviewing the Node.js and React skills; the other 10 technologies follow the same pattern