### PR TITLE
fix: use Node 24 in release workflow, add to CI matrix

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Run build
         run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run build
         run: npm run build
         env:
+          # build-providers.js fetches provider metadata from the GitHub API.
+          # Without authentication, parallel matrix jobs quickly exhaust the
+          # unauthenticated rate limit (60 req/h), causing the build to fail.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,6 +44,16 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
+      - name: Check npm version meets minimum for provenance publishing
+        run: |
+          NPM_VERSION=$(npm --version)
+          MIN_VERSION="11.5.1"
+          if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
+            echo "npm $NPM_VERSION is below required minimum $MIN_VERSION"
+            exit 1
+          fi
+          echo "npm $NPM_VERSION ok"
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,14 +40,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
-
-      - name: Update npm to >=11.5.1 (for OIDC support)
-        run: |
-          corepack enable
-          corepack prepare npm@11.12.1 --activate
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,7 +45,9 @@ jobs:
           cache: "npm"
 
       - name: Update npm to >=11.5.1 (for OIDC support)
-        run: npm install -g npm@^11.5.1
+        run: |
+          corepack enable
+          corepack prepare npm@11.12.1 --activate
 
       - name: Install dependencies
         run: npm ci

--- a/scripts/build-providers.js
+++ b/scripts/build-providers.js
@@ -175,30 +175,26 @@ async function buildProvidersBundle() {
   console.log('🔨 Building providers bundle...');
   const result = [];
 
-  try {
-    console.log('🌐 Fetching providers from GitHub repository open-feature/openfeature.dev ...');
-    const listing = await fetchProviderDirectoryListing();
+  console.log('🌐 Fetching providers from GitHub repository open-feature/openfeature.dev ...');
+  const listing = await fetchProviderDirectoryListing();
 
-    for (const entry of listing) {
-      if (!entry.download_url) continue;
+  for (const entry of listing) {
+    if (!entry.download_url) continue;
 
-      const content = await fetchRemoteProviderFile(entry.download_url);
-      if (!content) continue;
+    const content = await fetchRemoteProviderFile(entry.download_url);
+    if (!content) continue;
 
-      const base = path.basename(entry.name, '.ts');
-      if (base === 'index') continue; // skip barrel files
+    const base = path.basename(entry.name, '.ts');
+    if (base === 'index') continue; // skip barrel files
 
-      // Build per-technology docs from href entries only
-      const docsUrlByTechnology = extractDocsUrlByTech(content);
-      if (Object.keys(docsUrlByTechnology).length === 0) {
-        console.log(`⏭️  ${base}: Skipped (no docs URLs detected)`);
-        continue;
-      }
-      result.push({ name: base, docsUrlByTechnology });
-      console.log(`✅ ${base}: Parsed (remote)`);
+    // Build per-technology docs from href entries only
+    const docsUrlByTechnology = extractDocsUrlByTech(content);
+    if (Object.keys(docsUrlByTechnology).length === 0) {
+      console.log(`⏭️  ${base}: Skipped (no docs URLs detected)`);
+      continue;
     }
-  } catch (err) {
-    console.warn('⚠️  Failed to fetch providers from GitHub:', err?.message || err);
+    result.push({ name: base, docsUrlByTechnology });
+    console.log(`✅ ${base}: Parsed (remote)`);
   }
 
   // Generate TypeScript file
@@ -213,7 +209,7 @@ async function buildProvidersBundle() {
 import { z } from 'zod';
 import { type InstallTechnology } from './promptsBundle.generated.js';
 
-export const PROVIDERS: readonly string[] = [
+export const PROVIDERS = [
 ${providersArray}
 ] as const;
 

--- a/scripts/build-providers.js
+++ b/scripts/build-providers.js
@@ -213,7 +213,7 @@ async function buildProvidersBundle() {
 import { z } from 'zod';
 import { type InstallTechnology } from './promptsBundle.generated.js';
 
-export const PROVIDERS = [
+export const PROVIDERS: readonly string[] = [
 ${providersArray}
 ] as const;
 


### PR DESCRIPTION
## Summary

- Bumps release workflow from Node 22 to Node 24, which ships npm 11.x built-in, removing the need for the separate \"Update npm\" step that was failing on Node 22.22.x runners due to a broken bundled npm (`MODULE_NOT_FOUND: promise-retry`)
- Adds a fast-fail npm version check to guard against a future Node 24 image shipping a lower npm version than the 11.5.1 minimum required for provenance publishing
- Adds Node 24 to the pr-checks matrix alongside 18/20/22
- Passes `GITHUB_TOKEN` to the build step in pr-checks to avoid GitHub API rate limiting when parallel matrix jobs all fetch provider metadata simultaneously
- Removes the try/catch in `build-providers.js` that silently swallowed fetch errors, producing a broken empty bundle with no signal to CI

### Related

Fixes https://github.com/open-feature/mcp/actions/runs/24796942384/job/72569173417