### PR TITLE
fix: exit process when stdio peers disconnect to prevent CPU-spin loop

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -92,15 +92,35 @@ export async function startServer(): Promise<void> {
   });
   process.on('uncaughtException', (err) => {
     console.error('Uncaught exception:', err);
+    // Always exit after an uncaught exception — process state is undefined and
+    // continuing causes a tight CPU-spinning loop when stdio peers are gone
+    // (e.g. the MCP host restarted and closed the socket).
+    process.exit(1);
   });
   process.on('unhandledRejection', (reason) => {
     console.error('Unhandled rejection:', reason);
+    process.exit(1);
+  });
+
+  // Exit cleanly when the MCP host closes the stdin pipe.  Without this the
+  // process keeps running (and spinning) after the host disconnects.
+  process.stdin.on('close', () => {
+    console.error('stdin closed. Exiting server.');
+    process.exit(0);
   });
 
   transport.onclose = () => {
     console.error('Stdio transport closed. Exiting server.');
     process.exit(0);
   };
+
+  // Exit on stdout errors (e.g. EPIPE when the host closes its read end).
+  // StdioServerTransport only guards stdin; stdout errors become uncaught
+  // exceptions without this listener, triggering the CPU-spin loop.
+  process.stdout.on('error', (err) => {
+    console.error('stdout error:', err);
+    process.exit(1);
+  });
 
   await server.connect(transport);
   console.error('✅ OpenFeature MCP Server (stdio) started');

--- a/src/server.ts
+++ b/src/server.ts
@@ -117,7 +117,10 @@ export async function startServer(): Promise<void> {
   // Exit on stdout errors (e.g. EPIPE when the host closes its read end).
   // StdioServerTransport only guards stdin; stdout errors become uncaught
   // exceptions without this listener, triggering the CPU-spin loop.
-  process.stdout.on('error', (err) => {
+  process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EPIPE') {
+      process.exit(0);
+    }
     console.error('stdout error:', err);
     process.exit(1);
   });


### PR DESCRIPTION
## Summary

- Add `process.exit(1)` to `uncaughtException` and `unhandledRejection` handlers
- Add `process.stdin.on('close', ...)` to exit when the MCP host severs the pipe
- Add `process.stdout.on('error', ...)` to catch EPIPE before it becomes an uncaught exception

When an MCP host restarts and closes its stdio sockets, writes to stdout produce EPIPE errors that escalate to uncaught exceptions. The previous handler logged and returned without exiting, causing the process to spin at ~100% CPU indefinitely. The host times out, spawns a fresh instance, and the cycle repeats.